### PR TITLE
fix: add permissions to caller workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -2,7 +2,11 @@ name: Release PR
 
 on:
   push:
-    branches: [master]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-pr:


### PR DESCRIPTION
## Summary
- Adds `contents: write` and `pull-requests: write` permissions to the release-pr caller workflow
- Fixes branch trigger from `master` to `main` to match DragonLoot's default branch
- Reusable workflows cannot escalate permissions beyond what the caller grants, so the `permissions` block must be in the caller