### PR TITLE
fix: add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: Xerrion/wow-workflows/.github/workflows/release.yml@main


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: write` to the release caller workflow so the BigWigsMods packager can update GitHub Releases without a 403 error.