### PR TITLE
chore: add nul to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .release/
+nul
 
 # Libs managed by .pkgmeta externals (submodules Ace3 and LibAnimate are tracked separately)
 Libs/*


### PR DESCRIPTION
Add Windows reserved device name `nul` to .gitignore to suppress phantom untracked file.