### PR TITLE
feat: loot roll replacement

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,6 +9,7 @@ ignore = {
     "212/self",
     "211/ADDON_NAME",
     "211/_.*",  -- unused variables prefixed with underscore
+    "213/_.*",  -- unused loop variables prefixed with underscore
 }
 
 globals = {
@@ -16,6 +17,7 @@ globals = {
     "SLASH_DRAGONLOOT1",
     "SLASH_DRAGONLOOT2",
     "SlashCmdList",
+    "StaticPopupDialogs",
 }
 
 read_globals = {
@@ -34,10 +36,12 @@ read_globals = {
 
     -- WoW API - Loot
     "GetNumLootItems", "GetLootSlotInfo", "GetLootSlotLink", "GetLootSlotType",
-    "LootSlot", "CloseLoot", "IsFishingLoot",
+    "LootSlot", "CloseLoot", "IsFishingLoot", "C_Loot",
 
     -- WoW API - Loot Roll
     "GetLootRollItemInfo", "GetLootRollItemLink", "RollOnLoot", "GetLootRollTimeLeft",
+    "GetActiveLootRollIDs", "ConfirmLootRoll",
+    "StaticPopup_Show", "HandleModifiedItemClick",
 
     -- WoW API - Loot History
     "C_LootHistory",
@@ -62,6 +66,7 @@ read_globals = {
     "GOLD_AMOUNT_TEXTURE", "SILVER_AMOUNT_TEXTURE", "COPPER_AMOUNT_TEXTURE",
     "GetCoinTextureString",
     "UNKNOWN",
+    "LOOT_NO_DROP", "YES", "NO",
 
     -- Ace3
     "LibStub",

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -44,6 +44,7 @@ ns.LootAnimations = {}
 ns.RollFrame = {}
 ns.RollAnimations = {}
 ns.RollManager = {}
+ns.RollListener = {}
 ns.HistoryFrame = {}
 ns.ConfigWindow = {}
 ns.MinimapIcon = {}

--- a/Display/RollAnimations.lua
+++ b/Display/RollAnimations.lua
@@ -1,0 +1,73 @@
+-------------------------------------------------------------------------------
+-- RollAnimations.lua
+-- LibAnimate-driven animations for roll frame entrance and exit
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- LibAnimate reference
+-------------------------------------------------------------------------------
+
+local lib = LibStub("LibAnimate")
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.RollAnimations
+-------------------------------------------------------------------------------
+
+function ns.RollAnimations.PlayShow(frame)
+    local db = ns.Addon.db.profile
+
+    if not db.animation.enabled then
+        frame:SetAlpha(1)
+        frame:SetScale(1)
+        frame:Show()
+        return
+    end
+
+    local duration = db.animation.openDuration or 0.3
+
+    frame:SetAlpha(0)
+    frame:Show()
+
+    ns.RollAnimations.StopAll(frame)
+
+    lib:Animate(frame, "slideInRight", {
+        duration = duration,
+        distance = 50,
+        onFinished = function()
+            local scale = ns.Addon.db and ns.Addon.db.profile.rollFrame.scale or 1.0
+            frame:SetScale(scale)
+        end,
+    })
+end
+
+function ns.RollAnimations.PlayHide(frame, onFinished)
+    local db = ns.Addon.db.profile
+
+    if not db.animation.enabled then
+        if onFinished then onFinished() end
+        return
+    end
+
+    local duration = db.animation.closeDuration or 0.5
+
+    ns.RollAnimations.StopAll(frame)
+
+    lib:Animate(frame, "fadeOut", {
+        duration = duration,
+        onFinished = function()
+            local scale = ns.Addon.db and ns.Addon.db.profile.rollFrame.scale or 1.0
+            frame:SetAlpha(1)
+            frame:SetScale(scale)
+            frame:Hide()
+            if onFinished then onFinished() end
+        end,
+    })
+end
+
+function ns.RollAnimations.StopAll(frame)
+    lib:ClearQueue(frame)
+end

--- a/Display/RollFrame.lua
+++ b/Display/RollFrame.lua
@@ -1,0 +1,591 @@
+-------------------------------------------------------------------------------
+-- RollFrame.lua
+-- Loot roll frame replacement with timer bar and roll buttons
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local CreateFrame = CreateFrame
+local GameTooltip = GameTooltip
+local UIParent = UIParent
+local GetLootRollItemInfo = GetLootRollItemInfo
+local GetLootRollItemLink = GetLootRollItemLink
+local RollOnLoot = RollOnLoot
+local ITEM_QUALITY_COLORS = ITEM_QUALITY_COLORS
+local STANDARD_TEXT_FONT = STANDARD_TEXT_FONT
+local HandleModifiedItemClick = HandleModifiedItemClick
+
+local LSM = LibStub("LibSharedMedia-3.0")
+
+-------------------------------------------------------------------------------
+-- Roll type constants (values used by RollOnLoot)
+-------------------------------------------------------------------------------
+
+local ROLL_PASS = 0
+local ROLL_NEED = 1
+local ROLL_GREED = 2
+local ROLL_DISENCHANT = 3
+local ROLL_TRANSMOG = 4
+
+-------------------------------------------------------------------------------
+-- Button icon textures
+-------------------------------------------------------------------------------
+
+local NEED_ICON = "Interface\\Buttons\\UI-GroupLoot-Dice-Up"
+local GREED_ICON = "Interface\\Buttons\\UI-GroupLoot-Coin-Up"
+local DE_ICON = "Interface\\Buttons\\UI-GroupLoot-DE-Up"
+local PASS_ICON = "Interface\\Buttons\\UI-GroupLoot-Pass-Up"
+
+-------------------------------------------------------------------------------
+-- Frame dimensions
+-------------------------------------------------------------------------------
+
+local FRAME_WIDTH = 280
+local FRAME_BASE_HEIGHT = 54
+local ICON_SIZE = 36
+local BUTTON_SIZE = 24
+local FRAME_SPACING = 4
+local MAX_VISIBLE_ROLLS = 4
+
+-------------------------------------------------------------------------------
+-- Roll frame pool
+-------------------------------------------------------------------------------
+
+local rollFramePool = {}
+local rollFrameCount = 0
+local anchorFrame
+
+-------------------------------------------------------------------------------
+-- Quality color helper
+-------------------------------------------------------------------------------
+
+local function GetQualityColor(quality)
+    if quality and ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality] then
+        local qc = ITEM_QUALITY_COLORS[quality]
+        return qc.r, qc.g, qc.b
+    end
+    if quality and ns.QUALITY_COLORS and ns.QUALITY_COLORS[quality] then
+        local qc = ns.QUALITY_COLORS[quality]
+        return qc.r, qc.g, qc.b
+    end
+    return 1, 1, 1
+end
+
+-------------------------------------------------------------------------------
+-- Font helper
+-------------------------------------------------------------------------------
+
+local function GetFont()
+    local db = ns.Addon.db.profile
+    local fontPath = LSM:Fetch("font", db.appearance.font) or STANDARD_TEXT_FONT
+    return fontPath, db.appearance.fontSize
+end
+
+-------------------------------------------------------------------------------
+-- Timer bar color interpolation (green -> yellow -> red)
+-------------------------------------------------------------------------------
+
+local function GetTimerBarColor(timeLeft, rollTime)
+    if rollTime <= 0 then return 1, 0, 0 end
+    local ratio = timeLeft / rollTime
+
+    if ratio > 0.5 then
+        -- Green to Yellow
+        local t = (ratio - 0.5) / 0.5
+        return 1 - t, 1, 0
+    else
+        -- Yellow to Red
+        local t = ratio / 0.5
+        return 1, t, 0
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Position persistence
+-------------------------------------------------------------------------------
+
+local function SaveFramePosition()
+    if not anchorFrame then return end
+    local db = ns.Addon.db.profile.rollFrame
+    local point, _, relativePoint, x, y = anchorFrame:GetPoint()
+    if point then
+        db.point = point
+        db.relativePoint = relativePoint
+        db.x = x
+        db.y = y
+    end
+end
+
+local function RestoreFramePosition()
+    if not anchorFrame then return end
+    local db = ns.Addon.db.profile.rollFrame
+    anchorFrame:ClearAllPoints()
+    if db.point then
+        anchorFrame:SetPoint(db.point, UIParent, db.relativePoint, db.x or 0, db.y or 0)
+    else
+        anchorFrame:SetPoint("TOP", UIParent, "TOP", 0, -200)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Button click handler
+-------------------------------------------------------------------------------
+
+local function OnRollButtonClick(self)
+    local rollID = self:GetParent().rollID
+    if rollID then
+        RollOnLoot(rollID, self.rollType)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Button tooltip handlers
+-------------------------------------------------------------------------------
+
+local ROLL_TOOLTIP_LABELS = {
+    [ROLL_NEED] = "Need",
+    [ROLL_GREED] = "Greed",
+    [ROLL_DISENCHANT] = "Disenchant",
+    [ROLL_PASS] = "Pass",
+    [ROLL_TRANSMOG] = "Transmog",
+}
+
+local function OnRollButtonEnter(self)
+    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    local label = ROLL_TOOLTIP_LABELS[self.rollType] or "Roll"
+    GameTooltip:SetText(label)
+    if self.disabledReason then
+        GameTooltip:AddLine(self.disabledReason, 1, 0.2, 0.2, true)
+    end
+    GameTooltip:Show()
+end
+
+local function OnRollButtonLeave()
+    GameTooltip:Hide()
+end
+
+-------------------------------------------------------------------------------
+-- Icon tooltip handlers
+-------------------------------------------------------------------------------
+
+local function OnIconEnter(self)
+    local rollID = self:GetParent().rollID
+    if rollID then
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetLootRollItem(rollID)
+        GameTooltip:Show()
+    end
+end
+
+local function OnIconLeave()
+    GameTooltip:Hide()
+end
+
+local function OnIconClick(self, button)
+    local rollID = self:GetParent().rollID
+    if not rollID then return end
+    if button == "LeftButton" then
+        local link = GetLootRollItemLink(rollID)
+        if link then
+            HandleModifiedItemClick(link)
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Create roll icon button
+-------------------------------------------------------------------------------
+
+local function CreateRollIcon(parent)
+    local btn = CreateFrame("Button", nil, parent)
+    btn:SetSize(ICON_SIZE, ICON_SIZE)
+    btn:SetPoint("LEFT", parent, "LEFT", 4, 0)
+    btn:RegisterForClicks("LeftButtonUp")
+
+    btn.icon = btn:CreateTexture(nil, "ARTWORK")
+    btn.icon:SetAllPoints()
+    btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+
+    btn.border = btn:CreateTexture(nil, "OVERLAY")
+    btn.border:SetPoint("TOPLEFT", btn, "TOPLEFT", -1, 1)
+    btn.border:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 1, -1)
+    btn.border:SetColorTexture(0.3, 0.3, 0.3, 0.8)
+    btn.icon:SetDrawLayer("OVERLAY", 1)
+
+    btn:SetScript("OnEnter", OnIconEnter)
+    btn:SetScript("OnLeave", OnIconLeave)
+    btn:SetScript("OnClick", OnIconClick)
+
+    return btn
+end
+
+-------------------------------------------------------------------------------
+-- Create generic roll action button
+-------------------------------------------------------------------------------
+
+local function CreateRollButton(parent, texture, rollType, size)
+    local btnSize = size or BUTTON_SIZE
+    local btn = CreateFrame("Button", nil, parent)
+    btn:SetSize(btnSize, btnSize)
+    btn.rollType = rollType
+
+    btn.icon = btn:CreateTexture(nil, "ARTWORK")
+    btn.icon:SetAllPoints()
+    btn.icon:SetTexture(texture)
+
+    btn.highlight = btn:CreateTexture(nil, "HIGHLIGHT")
+    btn.highlight:SetAllPoints()
+    btn.highlight:SetColorTexture(1, 1, 1, 0.2)
+
+    btn:SetScript("OnClick", OnRollButtonClick)
+    btn:SetScript("OnEnter", OnRollButtonEnter)
+    btn:SetScript("OnLeave", OnRollButtonLeave)
+
+    return btn
+end
+
+-------------------------------------------------------------------------------
+-- Create timer bar
+-------------------------------------------------------------------------------
+
+local function CreateTimerBar(parent)
+    local db = ns.Addon.db.profile
+    local barHeight = db.rollFrame.timerBarHeight or 12
+
+    local bar = CreateFrame("StatusBar", nil, parent)
+    bar:SetHeight(barHeight)
+    bar:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", ICON_SIZE + 10, 4)
+    bar:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -4, 4)
+    bar:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
+    bar:SetMinMaxValues(0, 1)
+    bar:SetValue(1)
+    bar:SetStatusBarColor(0, 1, 0)
+
+    bar.bg = bar:CreateTexture(nil, "BACKGROUND")
+    bar.bg:SetAllPoints()
+    bar.bg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
+
+    bar.text = bar:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    bar.text:SetPoint("CENTER", bar, "CENTER", 0, 0)
+    bar.text:SetTextColor(1, 1, 1)
+
+    return bar
+end
+
+-------------------------------------------------------------------------------
+-- Create a single roll frame
+-------------------------------------------------------------------------------
+
+local function CreateRollFrame(index)
+    rollFrameCount = rollFrameCount + 1
+    local frameName = "DragonLootRoll" .. rollFrameCount
+
+    local frame = CreateFrame("Frame", frameName, anchorFrame, "BackdropTemplate")
+    frame:SetSize(FRAME_WIDTH, FRAME_BASE_HEIGHT)
+    frame:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    frame:SetBackdropColor(0.05, 0.05, 0.05, 0.9)
+    frame:SetBackdropBorderColor(0.3, 0.3, 0.3, 0.8)
+    frame:SetFrameStrata("HIGH")
+    frame:SetFrameLevel(110)
+    frame:Hide()
+
+    -- Item icon
+    frame.iconFrame = CreateRollIcon(frame)
+
+    -- Item name
+    frame.itemName = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    frame.itemName:SetPoint("TOPLEFT", frame.iconFrame, "TOPRIGHT", 6, -1)
+    frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -4, 0)
+    frame.itemName:SetJustifyH("LEFT")
+    frame.itemName:SetWordWrap(false)
+
+    -- BoP indicator
+    frame.bindText = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    frame.bindText:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -4, -2)
+    frame.bindText:SetTextColor(1, 0.2, 0.2)
+    frame.bindText:Hide()
+
+    -- Timer bar
+    frame.timerBar = CreateTimerBar(frame)
+
+    -- Roll buttons (anchored right-to-left above timer bar)
+    frame.passButton = CreateRollButton(frame, PASS_ICON, ROLL_PASS)
+    frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -6, 6)
+
+    frame.disenchantButton = CreateRollButton(frame, DE_ICON, ROLL_DISENCHANT)
+    frame.disenchantButton:SetPoint("RIGHT", frame.passButton, "LEFT", -4, 0)
+
+    frame.greedButton = CreateRollButton(frame, GREED_ICON, ROLL_GREED)
+    frame.greedButton:SetPoint("RIGHT", frame.disenchantButton, "LEFT", -4, 0)
+
+    frame.needButton = CreateRollButton(frame, NEED_ICON, ROLL_NEED)
+    frame.needButton:SetPoint("RIGHT", frame.greedButton, "LEFT", -4, 0)
+
+    -- Transmog button - only functional on Retail where canTransmog is returned
+    frame.transmogButton = CreateRollButton(frame, nil, ROLL_TRANSMOG, BUTTON_SIZE)
+    local success = pcall(function() frame.transmogButton.icon:SetAtlas("transmog-icon-small") end)
+    if not success then
+        frame.transmogButton.icon:SetTexture("Interface\\ICONS\\INV_Enchant_Disenchant")
+    end
+    frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -4, 0)
+    frame.transmogButton:Hide()
+
+    frame.frameIndex = index
+    return frame
+end
+
+-------------------------------------------------------------------------------
+-- Configure roll button state (enabled/disabled with reason)
+-------------------------------------------------------------------------------
+
+local function SetButtonState(btn, canUse, reason)
+    if not btn then return end
+    if canUse then
+        btn:Enable()
+        btn.icon:SetDesaturated(false)
+        btn.icon:SetAlpha(1)
+        btn.disabledReason = nil
+    else
+        btn:Disable()
+        btn.icon:SetDesaturated(true)
+        btn.icon:SetAlpha(0.4)
+        btn.disabledReason = reason or "Not available for this item"
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Populate a roll frame with item data
+-------------------------------------------------------------------------------
+
+local function PopulateRollFrame(frame, rollID)
+    frame.rollID = rollID
+
+    local texture, name, count, quality, bindOnPickUp, canNeed, canGreed,
+          canDisenchant, reasonNeed, reasonGreed, reasonDisenchant,
+          _deSkillRequired, canTransmog = GetLootRollItemInfo(rollID)
+
+    if not texture then return end
+
+    local fontPath, fontSize = GetFont()
+    local r, g, b = GetQualityColor(quality)
+
+    -- Icon
+    frame.iconFrame.icon:SetTexture(texture)
+    frame.iconFrame.border:SetColorTexture(r, g, b, 0.8)
+
+    -- Item name
+    frame.itemName:SetFont(fontPath, fontSize, "OUTLINE")
+    frame.itemName:SetText(name or "")
+    frame.itemName:SetTextColor(r, g, b)
+
+    -- BoP indicator
+    if bindOnPickUp then
+        frame.bindText:SetText("BoP")
+        frame.bindText:Show()
+    else
+        frame.bindText:Hide()
+    end
+
+    -- Timer bar starts full
+    frame.timerBar:SetMinMaxValues(0, 1)
+    frame.timerBar:SetValue(1)
+    frame.timerBar:SetStatusBarColor(0, 1, 0)
+    frame.timerBar.text:SetText("")
+
+    -- Count text on icon (for stackable items)
+    if count and count > 1 then
+        if not frame.iconFrame.count then
+            frame.iconFrame.count = frame.iconFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+            frame.iconFrame.count:SetPoint("BOTTOMRIGHT", frame.iconFrame, "BOTTOMRIGHT", 2, -2)
+        end
+        frame.iconFrame.count:SetText(count)
+        frame.iconFrame.count:Show()
+    elseif frame.iconFrame.count then
+        frame.iconFrame.count:Hide()
+    end
+
+    -- Button states
+    SetButtonState(frame.needButton, canNeed, reasonNeed)
+    SetButtonState(frame.greedButton, canGreed, reasonGreed)
+    SetButtonState(frame.disenchantButton, canDisenchant, reasonDisenchant)
+    SetButtonState(frame.passButton, true, nil)
+
+    if frame.transmogButton then
+        if canTransmog then
+            frame.transmogButton:Show()
+            SetButtonState(frame.transmogButton, true, nil)
+        else
+            frame.transmogButton:Hide()
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Layout visible roll frames
+-------------------------------------------------------------------------------
+
+local function LayoutRollFrames()
+    local yOffset = 0
+    for i = 1, MAX_VISIBLE_ROLLS do
+        local frame = rollFramePool[i]
+        if frame and frame:IsShown() then
+            frame:ClearAllPoints()
+            frame:SetPoint("TOPLEFT", anchorFrame, "TOPLEFT", 0, -yOffset)
+            yOffset = yOffset + frame:GetHeight() + FRAME_SPACING
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Acquire / Release frames from pool
+-------------------------------------------------------------------------------
+
+local function AcquireRollFrame(index)
+    if not rollFramePool[index] then
+        rollFramePool[index] = CreateRollFrame(index)
+    end
+    return rollFramePool[index]
+end
+
+local function ReleaseRollFrame(index)
+    local frame = rollFramePool[index]
+    if not frame then return end
+    frame.rollID = nil
+    frame:Hide()
+end
+
+-------------------------------------------------------------------------------
+-- Create anchor frame
+-------------------------------------------------------------------------------
+
+local function CreateAnchorFrame()
+    local frame = CreateFrame("Frame", "DragonLootRollAnchor", UIParent)
+    frame:SetSize(FRAME_WIDTH, 1)
+    frame:SetClampedToScreen(true)
+
+    frame:EnableMouse(true)
+    frame:SetMovable(true)
+    frame:RegisterForDrag("LeftButton")
+
+    frame:SetScript("OnDragStart", function(self)
+        local db = ns.Addon.db.profile.rollFrame
+        if not db.lock then
+            self:StartMoving()
+        end
+    end)
+
+    frame:SetScript("OnDragStop", function(self)
+        self:StopMovingOrSizing()
+        SaveFramePosition()
+    end)
+
+    return frame
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.RollFrame
+-------------------------------------------------------------------------------
+
+function ns.RollFrame.Initialize()
+    if anchorFrame then return end
+    anchorFrame = CreateAnchorFrame()
+    ns.RollFrame.ApplySettings()
+    RestoreFramePosition()
+    ns.DebugPrint("RollFrame initialized")
+end
+
+function ns.RollFrame.Shutdown()
+    if not anchorFrame then return end
+    ns.RollFrame.HideAllRolls()
+    anchorFrame:Hide()
+    ns.DebugPrint("RollFrame shut down")
+end
+
+function ns.RollFrame.ShowRoll(frameIndex, rollID)
+    if not anchorFrame then return end
+
+    local frame = AcquireRollFrame(frameIndex)
+    PopulateRollFrame(frame, rollID)
+    frame:Show()
+
+    ns.RollAnimations.PlayShow(frame)
+    LayoutRollFrames()
+end
+
+function ns.RollFrame.HideRoll(frameIndex, onComplete)
+    local frame = rollFramePool[frameIndex]
+    if not frame or not frame:IsShown() then
+        ReleaseRollFrame(frameIndex)
+        if onComplete then onComplete() end
+        return
+    end
+
+    ns.RollAnimations.StopAll(frame)
+    ns.RollAnimations.PlayHide(frame, function()
+        ReleaseRollFrame(frameIndex)
+        LayoutRollFrames()
+        if onComplete then onComplete() end
+    end)
+end
+
+function ns.RollFrame.HideAllRolls()
+    for i = 1, MAX_VISIBLE_ROLLS do
+        local frame = rollFramePool[i]
+        if frame and frame:IsShown() then
+            ns.RollAnimations.StopAll(frame)
+            ReleaseRollFrame(i)
+        end
+    end
+    LayoutRollFrames()
+end
+
+function ns.RollFrame.UpdateTimer(frameIndex, timeLeft, rollTime)
+    local frame = rollFramePool[frameIndex]
+    if not frame or not frame:IsShown() then return end
+
+    local bar = frame.timerBar
+    bar:SetMinMaxValues(0, rollTime)
+    bar:SetValue(timeLeft)
+
+    local r, g, b = GetTimerBarColor(timeLeft, rollTime)
+    bar:SetStatusBarColor(r, g, b)
+    bar.text:SetText(string.format("%.0f", timeLeft))
+end
+
+function ns.RollFrame.ApplySettings()
+    if not anchorFrame then return end
+    local db = ns.Addon.db.profile
+
+    anchorFrame:SetScale(db.rollFrame.scale or 1.0)
+
+    local barHeight = db.rollFrame.timerBarHeight or 12
+    for i = 1, MAX_VISIBLE_ROLLS do
+        local frame = rollFramePool[i]
+        if frame then
+            frame.timerBar:SetHeight(barHeight)
+        end
+    end
+
+    LayoutRollFrames()
+end
+
+function ns.RollFrame.ResetAnchor()
+    if not anchorFrame then return end
+    local db = ns.Addon.db.profile.rollFrame
+    db.point = nil
+    db.relativePoint = nil
+    db.x = nil
+    db.y = nil
+    anchorFrame:ClearAllPoints()
+    anchorFrame:SetPoint("TOP", UIParent, "TOP", 0, -200)
+end

--- a/Display/RollManager.lua
+++ b/Display/RollManager.lua
@@ -1,0 +1,268 @@
+-------------------------------------------------------------------------------
+-- RollManager.lua
+-- Manages active loot rolls, overflow queue, and timer updates
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetTime = GetTime
+local max = math.max
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+local MAX_VISIBLE_ROLLS = 4
+local TIMER_INTERVAL = 0.05
+
+-------------------------------------------------------------------------------
+-- State
+-------------------------------------------------------------------------------
+
+local addon
+local activeRolls = {}      -- rollID -> { rollID, rollTime, startTime, frameIndex }
+local waitingRolls = {}     -- ordered list of { rollID, rollTime }
+local usedFrames = {}       -- frameIndex -> true/false
+local activeRollCount = 0
+local timerHandle
+
+-------------------------------------------------------------------------------
+-- StaticPopup for roll confirmations (shared by Retail and Classic listeners)
+-------------------------------------------------------------------------------
+
+StaticPopupDialogs["DRAGONLOOT_CONFIRM_LOOT_ROLL"] = {
+    text = LOOT_NO_DROP,
+    button1 = YES,
+    button2 = NO,
+    OnAccept = function(self)
+        ConfirmLootRoll(self.data.rollID, self.data.rollType)
+    end,
+    timeout = 0,
+    whileDead = 1,
+    hideOnEscape = 1,
+}
+
+-------------------------------------------------------------------------------
+-- Frame index management
+-------------------------------------------------------------------------------
+
+local function AcquireFrameIndex()
+    for i = 1, MAX_VISIBLE_ROLLS do
+        if not usedFrames[i] then
+            usedFrames[i] = true
+            return i
+        end
+    end
+    return nil
+end
+
+local function ReleaseFrameIndex(frameIndex)
+    usedFrames[frameIndex] = nil
+end
+
+-------------------------------------------------------------------------------
+-- Timer management
+-------------------------------------------------------------------------------
+
+local function StopTimer()
+    if timerHandle and addon then
+        addon:CancelTimer(timerHandle)
+        timerHandle = nil
+    end
+end
+
+local function OnTimerTick()
+    local now = GetTime()
+    for _rollID, roll in pairs(activeRolls) do
+        local elapsed = now - roll.startTime
+        local timeLeft = max(0, roll.rollTime - elapsed)
+        ns.RollFrame.UpdateTimer(roll.frameIndex, timeLeft, roll.rollTime)
+        -- Timer expired - Blizzard will send CANCEL_LOOT_ROLL, don't remove here
+        if timeLeft <= 0 then -- luacheck: ignore 542
+            -- Wait for the event
+        end
+    end
+end
+
+local function StartTimer()
+    if timerHandle then return end
+    if not addon then return end
+    timerHandle = addon:ScheduleRepeatingTimer(OnTimerTick, TIMER_INTERVAL)
+end
+
+-------------------------------------------------------------------------------
+-- Waiting queue helpers
+-------------------------------------------------------------------------------
+
+local function IsInWaitingQueue(rollID)
+    for _, entry in ipairs(waitingRolls) do
+        if entry.rollID == rollID then return true end
+    end
+    return false
+end
+
+local function RemoveFromWaitingQueue(rollID)
+    for i, entry in ipairs(waitingRolls) do
+        if entry.rollID == rollID then
+            table.remove(waitingRolls, i)
+            return true
+        end
+    end
+    return false
+end
+
+-------------------------------------------------------------------------------
+-- Queue promotion
+-------------------------------------------------------------------------------
+
+local function PromoteFromQueue()
+    if #waitingRolls == 0 then return end
+    if activeRollCount >= MAX_VISIBLE_ROLLS then return end
+
+    local entry = table.remove(waitingRolls, 1)
+    if not entry then return end
+
+    local frameIndex = AcquireFrameIndex()
+    if not frameIndex then return end
+
+    activeRolls[entry.rollID] = {
+        rollID = entry.rollID,
+        rollTime = entry.rollTime,
+        startTime = GetTime(),
+        frameIndex = frameIndex,
+    }
+    activeRollCount = activeRollCount + 1
+
+    ns.RollFrame.ShowRoll(frameIndex, entry.rollID)
+    StartTimer()
+end
+
+-------------------------------------------------------------------------------
+-- Start timer only when active rolls exist
+-------------------------------------------------------------------------------
+
+local function StartTimerIfNeeded()
+    if activeRollCount > 0 then
+        StartTimer()
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.RollManager
+-------------------------------------------------------------------------------
+
+function ns.RollManager.Initialize(addonRef)
+    addon = addonRef or ns.Addon
+
+    local db = addon.db and addon.db.profile
+    if not db or not db.rollFrame or not db.rollFrame.enabled then return end
+
+    ns.RollFrame.Initialize()
+    ns.RollListener.Initialize(addon)
+    ns.DebugPrint("RollManager initialized")
+end
+
+function ns.RollManager.Shutdown()
+    StopTimer()
+    ns.RollManager.CancelAllRolls()
+    ns.RollFrame.Shutdown()
+    ns.RollListener.Shutdown()
+    addon = nil
+    ns.DebugPrint("RollManager shut down")
+end
+
+function ns.RollManager.StartRoll(rollID, rollTime)
+    -- Guard against duplicate events
+    if activeRolls[rollID] or IsInWaitingQueue(rollID) then return end
+
+    if activeRollCount < MAX_VISIBLE_ROLLS then
+        local frameIndex = AcquireFrameIndex()
+        if not frameIndex then return end
+
+        activeRolls[rollID] = {
+            rollID = rollID,
+            rollTime = rollTime,
+            startTime = GetTime(),
+            frameIndex = frameIndex,
+        }
+        activeRollCount = activeRollCount + 1
+
+        ns.RollFrame.ShowRoll(frameIndex, rollID)
+        StartTimer()
+    else
+        waitingRolls[#waitingRolls + 1] = { rollID = rollID, rollTime = rollTime }
+    end
+end
+
+function ns.RollManager.RecoverRoll(rollID, totalDuration, timeLeft)
+    if activeRolls[rollID] or IsInWaitingQueue(rollID) then return end
+
+    local frameIndex = AcquireFrameIndex()
+    if frameIndex then
+        local now = GetTime()
+        activeRolls[rollID] = {
+            rollID = rollID,
+            rollTime = totalDuration,
+            startTime = now - (totalDuration - timeLeft),
+            frameIndex = frameIndex,
+        }
+        activeRollCount = activeRollCount + 1
+        ns.RollFrame.ShowRoll(frameIndex, rollID)
+        StartTimerIfNeeded()
+    else
+        waitingRolls[#waitingRolls + 1] = { rollID = rollID, rollTime = totalDuration }
+    end
+end
+
+function ns.RollManager.CancelRoll(rollID)
+    local roll = activeRolls[rollID]
+    if roll then
+        local frameIndex = roll.frameIndex
+        activeRolls[rollID] = nil
+        activeRollCount = activeRollCount - 1
+        if activeRollCount <= 0 then
+            activeRollCount = 0
+            StopTimer()
+        end
+        -- Defer frame release and queue promotion until hide animation completes
+        ns.RollFrame.HideRoll(frameIndex, function()
+            ReleaseFrameIndex(frameIndex)
+            PromoteFromQueue()
+        end)
+        return
+    end
+
+    -- Check waiting queue
+    RemoveFromWaitingQueue(rollID)
+end
+
+function ns.RollManager.CancelAllRolls()
+    for rollID, roll in pairs(activeRolls) do
+        activeRolls[rollID] = nil
+        ReleaseFrameIndex(roll.frameIndex)
+    end
+    activeRollCount = 0
+    wipe(waitingRolls)
+    StopTimer()
+    ns.RollFrame.HideAllRolls()
+end
+
+function ns.RollManager.OnRollComplete(rollID)
+    if rollID then
+        ns.RollManager.CancelRoll(rollID)
+    end
+end
+
+function ns.RollManager.ApplySettings()
+    ns.RollFrame.ApplySettings()
+end
+
+function ns.RollManager.GetActiveRollCount()
+    return activeRollCount
+end

--- a/DragonLoot.toc
+++ b/DragonLoot.toc
@@ -26,17 +26,24 @@ Core\SlashCommands.lua
 # Display (shared)
 Display\LootFrame.lua
 Display\LootAnimations.lua
+Display\RollFrame.lua
+Display\RollAnimations.lua
+Display\RollManager.lua
 
 # Version-specific listeners
 #@retail@
 Listeners\LootListener_Retail.lua
+Listeners\RollListener_Retail.lua
 #@end-retail@
 #@tbc-anniversary@
 Listeners\LootListener_Classic.lua
+Listeners\RollListener_Classic.lua
 #@end-tbc-anniversary@
 #@version-mists@
 Listeners\LootListener_Classic.lua
+Listeners\RollListener_Classic.lua
 #@end-version-mists@
 #@version-cata@
 Listeners\LootListener_Classic.lua
+Listeners\RollListener_Classic.lua
 #@end-version-cata@

--- a/Listeners/RollListener_Classic.lua
+++ b/Listeners/RollListener_Classic.lua
@@ -1,0 +1,107 @@
+-------------------------------------------------------------------------------
+-- RollListener_Classic.lua
+-- Loot roll event handling for Classic, TBC Anniversary, Cata, MoP Classic
+--
+-- Supported versions: MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Version guard: skip on Retail (Classic listener runs on everything else)
+-------------------------------------------------------------------------------
+
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then return end
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetActiveLootRollIDs = GetActiveLootRollIDs
+local GetLootRollTimeLeft = GetLootRollTimeLeft
+local StaticPopup_Show = StaticPopup_Show
+
+-------------------------------------------------------------------------------
+-- State
+-------------------------------------------------------------------------------
+
+local addon
+local isRollActive = false
+
+-------------------------------------------------------------------------------
+-- Event Handlers
+-------------------------------------------------------------------------------
+
+local function OnStartLootRoll(_, rollID, rollTime)
+    if not isRollActive then return end
+    ns.RollManager.StartRoll(rollID, rollTime)
+    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTime))
+end
+
+local function OnCancelLootRoll(_, rollID)
+    if not isRollActive then return end
+    ns.RollManager.CancelRoll(rollID)
+    ns.DebugPrint("CANCEL_LOOT_ROLL: rollID=" .. tostring(rollID))
+end
+
+local function OnConfirmRoll(_, rollID, rollType)
+    local dialog = StaticPopup_Show("DRAGONLOOT_CONFIRM_LOOT_ROLL")
+    if dialog then
+        dialog.data = { rollID = rollID, rollType = rollType }
+    end
+end
+
+local function OnLootRollsComplete(_, lootHandle)
+    if not isRollActive then return end
+    ns.RollManager.OnRollComplete(lootHandle)
+    ns.DebugPrint("LOOT_ROLLS_COMPLETE: handle=" .. tostring(lootHandle))
+end
+
+-------------------------------------------------------------------------------
+-- Pending roll recovery (handles /reload during active rolls)
+-------------------------------------------------------------------------------
+
+local function RecoverActiveRolls()
+    if not GetActiveLootRollIDs then return end
+    local activeRollIDs = GetActiveLootRollIDs()
+    if not activeRollIDs then return end
+    for _, rollID in ipairs(activeRollIDs) do
+        local timeLeft = GetLootRollTimeLeft(rollID)
+        if timeLeft and timeLeft > 0 then
+            ns.RollManager.RecoverRoll(rollID, timeLeft, timeLeft)
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.RollListener
+-------------------------------------------------------------------------------
+
+function ns.RollListener.Initialize(addonRef)
+    addon = addonRef
+    isRollActive = true
+
+    addon:RegisterEvent("START_LOOT_ROLL", OnStartLootRoll)
+    addon:RegisterEvent("CANCEL_LOOT_ROLL", OnCancelLootRoll)
+    addon:RegisterEvent("CONFIRM_LOOT_ROLL", OnConfirmRoll)
+    addon:RegisterEvent("CONFIRM_DISENCHANT_ROLL", OnConfirmRoll)
+    addon:RegisterEvent("LOOT_ROLLS_COMPLETE", OnLootRollsComplete)
+
+    RecoverActiveRolls()
+
+    ns.DebugPrint("Classic Roll Listener initialized")
+end
+
+function ns.RollListener.Shutdown()
+    isRollActive = false
+
+    if addon then
+        addon:UnregisterEvent("START_LOOT_ROLL")
+        addon:UnregisterEvent("CANCEL_LOOT_ROLL")
+        addon:UnregisterEvent("CONFIRM_LOOT_ROLL")
+        addon:UnregisterEvent("CONFIRM_DISENCHANT_ROLL")
+        addon:UnregisterEvent("LOOT_ROLLS_COMPLETE")
+    end
+
+    ns.DebugPrint("Classic Roll Listener shut down")
+end

--- a/Listeners/RollListener_Retail.lua
+++ b/Listeners/RollListener_Retail.lua
@@ -1,0 +1,120 @@
+-------------------------------------------------------------------------------
+-- RollListener_Retail.lua
+-- Loot roll event handling for Retail (The War Within, Midnight)
+--
+-- Supported versions: Retail
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Version guard: only run on Retail
+-------------------------------------------------------------------------------
+
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetActiveLootRollIDs = GetActiveLootRollIDs
+local GetLootRollTimeLeft = GetLootRollTimeLeft
+local StaticPopup_Show = StaticPopup_Show
+
+-------------------------------------------------------------------------------
+-- State
+-------------------------------------------------------------------------------
+
+local addon
+local isRollActive = false
+
+-------------------------------------------------------------------------------
+-- Event Handlers
+-------------------------------------------------------------------------------
+
+local function OnStartLootRoll(_, rollID, rollTime)
+    if not isRollActive then return end
+    ns.RollManager.StartRoll(rollID, rollTime)
+    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTime))
+end
+
+local function OnCancelLootRoll(_, rollID)
+    if not isRollActive then return end
+    ns.RollManager.CancelRoll(rollID)
+    ns.DebugPrint("CANCEL_LOOT_ROLL: rollID=" .. tostring(rollID))
+end
+
+local function OnCancelAllLootRolls()
+    if not isRollActive then return end
+    ns.RollManager.CancelAllRolls()
+    ns.DebugPrint("CANCEL_ALL_LOOT_ROLLS")
+end
+
+local function OnConfirmRoll(_, rollID, rollType)
+    local dialog = StaticPopup_Show("DRAGONLOOT_CONFIRM_LOOT_ROLL")
+    if dialog then
+        dialog.data = { rollID = rollID, rollType = rollType }
+    end
+end
+
+local function OnLootRollsComplete(_, lootHandle)
+    if not isRollActive then return end
+    ns.RollManager.OnRollComplete(lootHandle)
+    ns.DebugPrint("LOOT_ROLLS_COMPLETE: handle=" .. tostring(lootHandle))
+end
+
+-------------------------------------------------------------------------------
+-- Pending roll recovery (handles /reload during active rolls)
+-------------------------------------------------------------------------------
+
+local function RecoverActiveRolls()
+    if not GetActiveLootRollIDs then return end
+
+    local activeRollIDs = GetActiveLootRollIDs()
+    if not activeRollIDs then return end
+
+    local GetRollDuration = C_Loot and C_Loot.GetLootRollDuration
+    for _, rollID in ipairs(activeRollIDs) do
+        local timeLeft = GetLootRollTimeLeft(rollID)
+        if timeLeft and timeLeft > 0 then
+            local totalDuration = GetRollDuration and GetRollDuration(rollID) or timeLeft
+            ns.RollManager.RecoverRoll(rollID, totalDuration or timeLeft, timeLeft)
+            ns.DebugPrint("Recovered active roll: " .. tostring(rollID))
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.RollListener
+-------------------------------------------------------------------------------
+
+function ns.RollListener.Initialize(addonRef)
+    addon = addonRef
+    isRollActive = true
+
+    addon:RegisterEvent("START_LOOT_ROLL", OnStartLootRoll)
+    addon:RegisterEvent("CANCEL_LOOT_ROLL", OnCancelLootRoll)
+    addon:RegisterEvent("CANCEL_ALL_LOOT_ROLLS", OnCancelAllLootRolls)
+    addon:RegisterEvent("CONFIRM_LOOT_ROLL", OnConfirmRoll)
+    addon:RegisterEvent("CONFIRM_DISENCHANT_ROLL", OnConfirmRoll)
+    addon:RegisterEvent("LOOT_ROLLS_COMPLETE", OnLootRollsComplete)
+
+    RecoverActiveRolls()
+
+    ns.DebugPrint("Retail Roll Listener initialized")
+end
+
+function ns.RollListener.Shutdown()
+    isRollActive = false
+
+    if addon then
+        addon:UnregisterEvent("START_LOOT_ROLL")
+        addon:UnregisterEvent("CANCEL_LOOT_ROLL")
+        addon:UnregisterEvent("CANCEL_ALL_LOOT_ROLLS")
+        addon:UnregisterEvent("CONFIRM_LOOT_ROLL")
+        addon:UnregisterEvent("CONFIRM_DISENCHANT_ROLL")
+        addon:UnregisterEvent("LOOT_ROLLS_COMPLETE")
+    end
+
+    ns.DebugPrint("Retail Roll Listener shut down")
+end


### PR DESCRIPTION
## Summary

Replaces the default WoW loot roll frame with a custom DragonLoot implementation featuring animated timer bars and an overflow queue system.

## Changes

- **RollFrame** (`Display/RollFrame.lua`) - Frame pool pattern supporting up to 4 simultaneous roll frames. Each frame includes a prominent timer bar with green-yellow-red color interpolation, Need/Greed/Disenchant/Pass/Transmog buttons with tooltip explanations, item icon with quality border, and StaticPopup confirmation for BoP rolls.
- **RollManager** (`Display/RollManager.lua`) - Coordinates active roll frames with an overflow queue, timer ticking via `OnUpdate`, and frame lifecycle management. Supports roll recovery after `/reload` via `GetActiveLootRollIDs`.
- **RollAnimations** (`Display/RollAnimations.lua`) - Slide-in and fade-out animations using LibAnimate's `slideInRight`/`fadeOut`. Deferred animation completion prevents frame overlap on queue promotion.
- **RollListener_Retail** (`Listeners/RollListener_Retail.lua`) - Handles Retail-specific roll events including `START_LOOT_ROLL`, `CANCEL_LOOT_ROLL`, and `CANCEL_ALL_LOOT_ROLLS`.
- **RollListener_Classic** (`Listeners/RollListener_Classic.lua`) - Handles TBC/MoP/Cata Classic roll events with the classic API surface.
- **Supporting changes** - Updated `.luacheckrc` with new globals, `Init.lua` with roll module registration, and `.toc` with file loading order.

## Stats

8 files changed, 1173 insertions(+), 1 deletion(-)