### PR TITLE
feat: loot history frame with encounter-based and roll-item tracking

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -27,7 +27,8 @@ read_globals = {
 
     -- WoW API - General
     "CreateFrame", "GetTime", "IsInInstance", "UnitName", "UnitClass",
-    "GetItemInfo", "GetItemQualityColor", "C_Timer", "C_Item", "C_Container",
+    "GetItemInfo", "GetItemInfoInstant", "GetItemQualityColor",
+    "C_Timer", "C_Item", "C_Container",
     "GameTooltip", "UIParent", "PlaySound", "PlaySoundFile",
     "ChatFrame_OpenChat", "IsShiftKeyDown",
     "InCombatLockdown", "hooksecurefunc",

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -46,6 +46,7 @@ ns.RollAnimations = {}
 ns.RollManager = {}
 ns.RollListener = {}
 ns.HistoryFrame = {}
+ns.HistoryListener = {}
 ns.ConfigWindow = {}
 ns.MinimapIcon = {}
 ns.Listeners = {}
@@ -185,6 +186,7 @@ function Addon:OnEnable()
     if ns.LootFrame.Initialize then ns.LootFrame.Initialize() end
     if ns.RollManager.Initialize then ns.RollManager.Initialize() end
     if ns.HistoryFrame.Initialize then ns.HistoryFrame.Initialize() end
+    if ns.HistoryListener.Initialize then ns.HistoryListener.Initialize(self) end
     if ns.Listeners.Initialize then ns.Listeners.Initialize(self) end
 end
 
@@ -196,6 +198,7 @@ function Addon:OnDisable()
     -- Shutdown modules if present
     if ns.LootFrame.Shutdown then ns.LootFrame.Shutdown() end
     if ns.RollManager.Shutdown then ns.RollManager.Shutdown() end
+    if ns.HistoryListener.Shutdown then ns.HistoryListener.Shutdown() end
     if ns.HistoryFrame.Shutdown then ns.HistoryFrame.Shutdown() end
     if ns.Listeners.Shutdown then ns.Listeners.Shutdown() end
 end

--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -23,6 +23,7 @@ local function PrintHelp()
     print("  " .. ns.COLOR_WHITE .. "/dl disable" .. ns.COLOR_RESET .. " - Disable addon")
     print("  " .. ns.COLOR_WHITE .. "/dl reset" .. ns.COLOR_RESET .. " - Reset loot frame position")
     print("  " .. ns.COLOR_WHITE .. "/dl test" .. ns.COLOR_RESET .. " - Show test loot")
+    print("  " .. ns.COLOR_WHITE .. "/dl history" .. ns.COLOR_RESET .. " - Toggle loot history")
     print("  " .. ns.COLOR_WHITE .. "/dl status" .. ns.COLOR_RESET .. " - Show current settings")
     print("  " .. ns.COLOR_WHITE .. "/dl help" .. ns.COLOR_RESET .. " - Show this help")
 end
@@ -103,6 +104,13 @@ local commandHandlers = {
             ns.LootFrame.ShowTestLoot()
         else
             ns.Print("Test loot not yet available.")
+        end
+    end,
+    ["history"] = function()
+        if ns.HistoryFrame.Toggle then
+            ns.HistoryFrame.Toggle()
+        else
+            ns.Print("Loot history not yet available.")
         end
     end,
 }

--- a/Display/HistoryFrame.lua
+++ b/Display/HistoryFrame.lua
@@ -1,0 +1,671 @@
+-------------------------------------------------------------------------------
+-- HistoryFrame.lua
+-- Loot history display with scrollable list of recent loot events
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local CreateFrame = CreateFrame
+local GameTooltip = GameTooltip
+local UIParent = UIParent
+local GetTime = GetTime
+local ITEM_QUALITY_COLORS = ITEM_QUALITY_COLORS
+local STANDARD_TEXT_FONT = STANDARD_TEXT_FONT
+local RAID_CLASS_COLORS = RAID_CLASS_COLORS
+local HandleModifiedItemClick = HandleModifiedItemClick
+local math_floor = math.floor
+
+local LSM = LibStub("LibSharedMedia-3.0")
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+local FRAME_WIDTH = 350
+local FRAME_HEIGHT = 400
+local TITLE_BAR_HEIGHT = 24
+local ENTRY_HEIGHT = 30
+local ENTRY_SPACING = 2
+local ENTRY_ICON_SIZE = 24
+local PADDING = 6
+local SCROLL_STEP = 3
+local SCROLLBAR_WIDTH = 14
+
+-------------------------------------------------------------------------------
+-- Frame references
+-------------------------------------------------------------------------------
+
+local containerFrame
+local scrollFrame
+local scrollChild
+local scrollBar
+
+-------------------------------------------------------------------------------
+-- Entry frame pool
+-------------------------------------------------------------------------------
+
+local entryPool = {}
+local entryCount = 0
+local activeEntries = {}
+
+-------------------------------------------------------------------------------
+-- History data (populated by listeners)
+-------------------------------------------------------------------------------
+
+ns.historyData = {}
+
+-------------------------------------------------------------------------------
+-- Quality color helper
+-------------------------------------------------------------------------------
+
+local function GetQualityColor(quality)
+    if quality and ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality] then
+        local qc = ITEM_QUALITY_COLORS[quality]
+        return qc.r, qc.g, qc.b
+    end
+    if quality and ns.QUALITY_COLORS and ns.QUALITY_COLORS[quality] then
+        local qc = ns.QUALITY_COLORS[quality]
+        return qc.r, qc.g, qc.b
+    end
+    return 1, 1, 1
+end
+
+-------------------------------------------------------------------------------
+-- Font helper
+-------------------------------------------------------------------------------
+
+local function GetFont()
+    local db = ns.Addon.db.profile
+    local fontPath = LSM:Fetch("font", db.appearance.font) or STANDARD_TEXT_FONT
+    return fontPath, db.appearance.fontSize
+end
+
+-------------------------------------------------------------------------------
+-- Class color helper
+-------------------------------------------------------------------------------
+
+local function GetClassColor(class)
+    if class and RAID_CLASS_COLORS and RAID_CLASS_COLORS[class] then
+        local cc = RAID_CLASS_COLORS[class]
+        return cc.r, cc.g, cc.b
+    end
+    return 0.7, 0.7, 0.7
+end
+
+-------------------------------------------------------------------------------
+-- Roll type text helper
+-------------------------------------------------------------------------------
+
+local ROLL_TYPE_TEXT = {
+    [0] = "Pass",
+    [1] = "Need",
+    [2] = "Greed",
+    [3] = "Disenchant",
+}
+
+local function GetRollTypeText(rollType)
+    return ROLL_TYPE_TEXT[rollType] or ""
+end
+
+-------------------------------------------------------------------------------
+-- Time formatting helper
+-------------------------------------------------------------------------------
+
+local function FormatTimeAgo(timestamp)
+    if not timestamp then return "" end
+    local elapsed = GetTime() - timestamp
+    if elapsed < 0 then elapsed = 0 end
+
+    if elapsed < 60 then
+        return math_floor(elapsed) .. "s ago"
+    elseif elapsed < 3600 then
+        return math_floor(elapsed / 60) .. "m ago"
+    else
+        return math_floor(elapsed / 3600) .. "h ago"
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Entry frame creation
+-------------------------------------------------------------------------------
+
+local function CreateEntryFrame()
+    entryCount = entryCount + 1
+    local frameName = "DragonLootHistoryEntry" .. entryCount
+
+    local entry = CreateFrame("Button", frameName, scrollChild)
+    entry:SetHeight(ENTRY_HEIGHT)
+    entry:EnableMouse(true)
+    entry:RegisterForClicks("LeftButtonUp")
+
+    -- Icon
+    entry.icon = entry:CreateTexture(nil, "ARTWORK")
+    entry.icon:SetSize(ENTRY_ICON_SIZE, ENTRY_ICON_SIZE)
+    entry.icon:SetPoint("LEFT", entry, "LEFT", 2, 0)
+    entry.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+
+    -- Icon border
+    entry.iconBorder = entry:CreateTexture(nil, "OVERLAY")
+    entry.iconBorder:SetPoint("TOPLEFT", entry.icon, "TOPLEFT", -1, 1)
+    entry.iconBorder:SetPoint("BOTTOMRIGHT", entry.icon, "BOTTOMRIGHT", 1, -1)
+    entry.iconBorder:SetColorTexture(0.3, 0.3, 0.3, 0.8)
+    entry.icon:SetDrawLayer("OVERLAY", 1)
+
+    -- Item name
+    entry.itemName = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.itemName:SetPoint("TOPLEFT", entry.icon, "TOPRIGHT", 4, -1)
+    entry.itemName:SetPoint("RIGHT", entry, "RIGHT", -60, 0)
+    entry.itemName:SetJustifyH("LEFT")
+    entry.itemName:SetWordWrap(false)
+
+    -- Winner name
+    entry.winnerName = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.winnerName:SetPoint("BOTTOMLEFT", entry.icon, "BOTTOMRIGHT", 4, 1)
+    entry.winnerName:SetJustifyH("LEFT")
+    entry.winnerName:SetWordWrap(false)
+
+    -- Roll info (e.g. "Need 87")
+    entry.rollInfo = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.rollInfo:SetPoint("LEFT", entry.winnerName, "RIGHT", 6, 0)
+    entry.rollInfo:SetJustifyH("LEFT")
+    entry.rollInfo:SetTextColor(0.8, 0.8, 0.8)
+
+    -- Time text
+    entry.timeText = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.timeText:SetPoint("RIGHT", entry, "RIGHT", -4, 0)
+    entry.timeText:SetJustifyH("RIGHT")
+    entry.timeText:SetTextColor(0.5, 0.5, 0.5)
+
+    -- Highlight
+    entry.highlight = entry:CreateTexture(nil, "HIGHLIGHT")
+    entry.highlight:SetAllPoints()
+    entry.highlight:SetColorTexture(1, 1, 1, 0.05)
+
+    return entry
+end
+
+-------------------------------------------------------------------------------
+-- Entry pool management
+-------------------------------------------------------------------------------
+
+local function AcquireEntry()
+    local entry = table.remove(entryPool)
+    if not entry then
+        entry = CreateEntryFrame()
+    end
+    entry._isPooled = false
+    return entry
+end
+
+local function ReleaseEntry(entry)
+    if entry._isPooled then return end
+    entry._isPooled = true
+    entry:Hide()
+    entry:ClearAllPoints()
+    entry.itemLink = nil
+    entry.icon:SetTexture(nil)
+    entry.itemName:SetText("")
+    entry.winnerName:SetText("")
+    entry.rollInfo:SetText("")
+    entry.timeText:SetText("")
+    entry:SetScript("OnClick", nil)
+    entry:SetScript("OnEnter", nil)
+    entry:SetScript("OnLeave", nil)
+    table.insert(entryPool, entry)
+end
+
+local function ReleaseAllEntries()
+    for i = #activeEntries, 1, -1 do
+        ReleaseEntry(activeEntries[i])
+        activeEntries[i] = nil
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Entry interaction handlers (shared across all entries to avoid closures)
+-------------------------------------------------------------------------------
+
+local function OnEntryEnter(self)
+    if self.itemLink then
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetHyperlink(self.itemLink)
+        GameTooltip:Show()
+    end
+end
+
+local function OnEntryLeave()
+    GameTooltip:Hide()
+end
+
+local function OnEntryClick(self)
+    if self.itemLink then
+        HandleModifiedItemClick(self.itemLink)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Populate an entry frame with history data
+-------------------------------------------------------------------------------
+
+local function PopulateEntry(entry, data)
+    entry.itemLink = data.itemLink
+    entry.timestampValue = data.timestamp
+
+    -- Icon
+    entry.icon:SetTexture(data.itemTexture)
+
+    -- Quality border
+    local qr, qg, qb = GetQualityColor(data.quality)
+    entry.iconBorder:SetColorTexture(qr, qg, qb, 0.8)
+
+    -- Item name (quality colored)
+    local fontPath, fontSize = GetFont()
+    entry.itemName:SetFont(fontPath, fontSize - 1, "OUTLINE")
+    if data.itemLink then
+        -- Extract name from link for display, fallback to link itself
+        local name = data.itemLink:match("%[(.-)%]") or data.itemLink
+        entry.itemName:SetText(name)
+    else
+        entry.itemName:SetText("Unknown Item")
+    end
+    entry.itemName:SetTextColor(qr, qg, qb)
+
+    -- Winner name (class colored)
+    entry.winnerName:SetFont(fontPath, fontSize - 2, "OUTLINE")
+    if data.winner then
+        local cr, cg, cb = GetClassColor(data.winnerClass)
+        entry.winnerName:SetText(data.winner)
+        entry.winnerName:SetTextColor(cr, cg, cb)
+    else
+        entry.winnerName:SetText("")
+    end
+
+    -- Roll info
+    entry.rollInfo:SetFont(fontPath, fontSize - 2, "OUTLINE")
+    local rollText = GetRollTypeText(data.rollType)
+    if data.roll then
+        rollText = rollText .. " " .. data.roll
+    end
+    entry.rollInfo:SetText(rollText)
+
+    -- Time
+    entry.timeText:SetFont(fontPath, fontSize - 2, "OUTLINE")
+    entry.timeText:SetText(FormatTimeAgo(data.timestamp))
+
+    -- Interaction scripts (named functions, no per-entry closures)
+    entry:SetScript("OnEnter", OnEntryEnter)
+    entry:SetScript("OnLeave", OnEntryLeave)
+    entry:SetScript("OnClick", OnEntryClick)
+
+    entry:Show()
+end
+
+-------------------------------------------------------------------------------
+-- Scroll bar update helper
+-------------------------------------------------------------------------------
+
+local function UpdateScrollBar()
+    if not scrollBar or not scrollFrame then return end
+    local contentHeight = scrollChild:GetHeight()
+    local visibleHeight = scrollFrame:GetHeight()
+    local maxScroll = contentHeight - visibleHeight
+    if maxScroll < 0 then maxScroll = 0 end
+
+    scrollBar:SetMinMaxValues(0, maxScroll)
+    if maxScroll == 0 then
+        scrollBar:Hide()
+    else
+        scrollBar:Show()
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Refresh history display
+-------------------------------------------------------------------------------
+
+local function RefreshHistory()
+    if not containerFrame or not containerFrame:IsShown() then return end
+
+    ReleaseAllEntries()
+
+    local yOffset = 0
+    for i, data in ipairs(ns.historyData) do
+        local entry = AcquireEntry()
+        PopulateEntry(entry, data)
+        entry:ClearAllPoints()
+        entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", 0, -yOffset)
+        entry:SetPoint("RIGHT", scrollChild, "RIGHT", 0, 0)
+        activeEntries[i] = entry
+        yOffset = yOffset + ENTRY_HEIGHT + ENTRY_SPACING
+    end
+
+    -- Resize scroll child to fit all entries
+    local totalHeight = #ns.historyData * (ENTRY_HEIGHT + ENTRY_SPACING)
+    if totalHeight < 1 then totalHeight = 1 end
+    scrollChild:SetHeight(totalHeight)
+
+    UpdateScrollBar()
+end
+
+-------------------------------------------------------------------------------
+-- Position persistence
+-------------------------------------------------------------------------------
+
+local function SaveFramePosition()
+    if not containerFrame then return end
+    local db = ns.Addon.db.profile
+    if not db.history then return end
+    local point, _, relativePoint, x, y = containerFrame:GetPoint()
+    if point then
+        db.history.point = point
+        db.history.relativePoint = relativePoint
+        db.history.x = x
+        db.history.y = y
+    end
+end
+
+local function RestoreFramePosition()
+    if not containerFrame then return end
+    local db = ns.Addon.db.profile
+    if not db.history then return end
+    containerFrame:ClearAllPoints()
+    if db.history.point then
+        containerFrame:SetPoint(db.history.point, UIParent, db.history.relativePoint,
+            db.history.x or 0, db.history.y or 0)
+    else
+        containerFrame:SetPoint("CENTER", UIParent, "CENTER", 200, 0)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Title bar creation
+-------------------------------------------------------------------------------
+
+local function CreateTitleBar(parent)
+    local titleBar = CreateFrame("Frame", nil, parent)
+    titleBar:SetHeight(TITLE_BAR_HEIGHT)
+    titleBar:SetPoint("TOPLEFT", parent, "TOPLEFT", 0, 0)
+    titleBar:SetPoint("TOPRIGHT", parent, "TOPRIGHT", 0, 0)
+
+    titleBar.text = titleBar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    titleBar.text:SetPoint("LEFT", titleBar, "LEFT", 8, 0)
+    titleBar.text:SetText("DragonLoot - Loot History")
+    titleBar.text:SetTextColor(1, 0.82, 0)
+
+    -- Close button
+    local closeBtn = CreateFrame("Button", nil, titleBar)
+    closeBtn:SetSize(16, 16)
+    closeBtn:SetPoint("TOPRIGHT", titleBar, "TOPRIGHT", -4, -4)
+    closeBtn:SetNormalTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Up")
+    closeBtn:SetPushedTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Down")
+    closeBtn:SetHighlightTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Highlight")
+    closeBtn:SetScript("OnClick", function()
+        ns.HistoryFrame.Hide()
+    end)
+
+    -- Clear button
+    local clearBtn = CreateFrame("Button", nil, titleBar)
+    clearBtn:SetSize(16, 16)
+    clearBtn:SetPoint("RIGHT", closeBtn, "LEFT", -4, 0)
+    clearBtn:SetNormalTexture("Interface\\Buttons\\UI-StopButton")
+    clearBtn:SetHighlightTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Highlight")
+    clearBtn:SetScript("OnClick", function()
+        ns.HistoryFrame.ClearHistory()
+    end)
+    clearBtn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetText("Clear History")
+        GameTooltip:Show()
+    end)
+    clearBtn:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+
+    return titleBar
+end
+
+-------------------------------------------------------------------------------
+-- Scroll frame creation
+-------------------------------------------------------------------------------
+
+local function OnScrollBarValueChanged(self, value)
+    if scrollFrame then
+        scrollFrame:SetVerticalScroll(value)
+    end
+end
+
+local function CreateScrollComponents(parent)
+    -- Scroll frame (clip region)
+    local sf = CreateFrame("ScrollFrame", "DragonLootHistoryScroll", parent)
+    sf:SetPoint("TOPLEFT", parent, "TOPLEFT", PADDING, -(TITLE_BAR_HEIGHT + PADDING))
+    sf:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -(PADDING + SCROLLBAR_WIDTH + 2), PADDING)
+
+    -- Scroll child
+    local child = CreateFrame("Frame", nil, sf)
+    child:SetWidth(sf:GetWidth() or (FRAME_WIDTH - PADDING * 2 - SCROLLBAR_WIDTH - 2))
+    child:SetHeight(1)
+    sf:SetScrollChild(child)
+
+    -- Scroll bar
+    local bar = CreateFrame("Slider", "DragonLootHistoryScrollBar", parent, "BackdropTemplate")
+    bar:SetWidth(SCROLLBAR_WIDTH)
+    bar:SetPoint("TOPRIGHT", parent, "TOPRIGHT", -PADDING, -(TITLE_BAR_HEIGHT + PADDING))
+    bar:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -PADDING, PADDING)
+    bar:SetOrientation("VERTICAL")
+    bar:SetMinMaxValues(0, 0)
+    bar:SetValue(0)
+    bar:SetValueStep(ENTRY_HEIGHT)
+    bar:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+    })
+    bar:SetBackdropColor(0.1, 0.1, 0.1, 0.5)
+
+    -- Thumb texture
+    bar.thumb = bar:CreateTexture(nil, "OVERLAY")
+    bar.thumb:SetColorTexture(0.4, 0.4, 0.4, 0.8)
+    bar.thumb:SetSize(SCROLLBAR_WIDTH - 2, 30)
+    bar:SetThumbTexture(bar.thumb)
+
+    bar:SetScript("OnValueChanged", OnScrollBarValueChanged)
+    bar:Hide()
+
+    -- Mouse wheel scrolling
+    sf:EnableMouseWheel(true)
+    sf:SetScript("OnMouseWheel", function(_, delta)
+        local current = bar:GetValue()
+        local step = ENTRY_HEIGHT * SCROLL_STEP
+        bar:SetValue(current - (delta * step))
+    end)
+
+    -- Update child width when scroll frame resizes
+    sf:SetScript("OnSizeChanged", function(self)
+        child:SetWidth(self:GetWidth())
+    end)
+
+    return sf, child, bar
+end
+
+-------------------------------------------------------------------------------
+-- Container frame creation
+-------------------------------------------------------------------------------
+
+local function CreateContainerFrame()
+    local frame = CreateFrame("Frame", "DragonLootHistoryFrame", UIParent, "BackdropTemplate")
+    frame:SetSize(FRAME_WIDTH, FRAME_HEIGHT)
+    frame:SetFrameStrata("HIGH")
+    frame:SetFrameLevel(100)
+    frame:SetClampedToScreen(true)
+    frame:Hide()
+
+    -- Backdrop
+    frame:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    frame:SetBackdropColor(0.05, 0.05, 0.05, 0.9)
+    frame:SetBackdropBorderColor(0.3, 0.3, 0.3, 0.8)
+
+    -- Title bar
+    frame.titleBar = CreateTitleBar(frame)
+
+    -- Dragging
+    frame:EnableMouse(true)
+    frame:SetMovable(true)
+    frame:RegisterForDrag("LeftButton")
+
+    frame:SetScript("OnDragStart", function(self)
+        self:StartMoving()
+    end)
+
+    frame:SetScript("OnDragStop", function(self)
+        self:StopMovingOrSizing()
+        SaveFramePosition()
+    end)
+
+    return frame
+end
+
+-------------------------------------------------------------------------------
+-- Time refresh ticker
+-------------------------------------------------------------------------------
+
+local timeRefreshHandle
+
+local function StartTimeRefresh()
+    if timeRefreshHandle then return end
+    timeRefreshHandle = ns.Addon:ScheduleRepeatingTimer(function()
+        if not containerFrame or not containerFrame:IsShown() then return end
+        local fontPath, fontSize = GetFont()
+        for _, entry in ipairs(activeEntries) do
+            if entry.timestampValue then
+                entry.timeText:SetFont(fontPath, fontSize - 2, "OUTLINE")
+                entry.timeText:SetText(FormatTimeAgo(entry.timestampValue))
+            end
+        end
+    end, 10)
+end
+
+local function StopTimeRefresh()
+    if timeRefreshHandle and ns.Addon then
+        ns.Addon:CancelTimer(timeRefreshHandle)
+        timeRefreshHandle = nil
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.HistoryFrame
+-------------------------------------------------------------------------------
+
+function ns.HistoryFrame.Initialize()
+    if containerFrame then return end
+    containerFrame = CreateContainerFrame()
+    scrollFrame, scrollChild, scrollBar = CreateScrollComponents(containerFrame)
+    ns.HistoryFrame.ApplySettings()
+    RestoreFramePosition()
+    ns.DebugPrint("HistoryFrame initialized")
+end
+
+function ns.HistoryFrame.Shutdown()
+    StopTimeRefresh()
+    if not containerFrame then return end
+    ReleaseAllEntries()
+    containerFrame:Hide()
+    ns.DebugPrint("HistoryFrame shut down")
+end
+
+function ns.HistoryFrame.Show()
+    if not containerFrame then return end
+    local db = ns.Addon.db.profile
+    if not db.history.enabled then return end
+    containerFrame:Show()
+    RefreshHistory()
+    StartTimeRefresh()
+end
+
+function ns.HistoryFrame.Hide()
+    if not containerFrame then return end
+    StopTimeRefresh()
+    containerFrame:Hide()
+end
+
+function ns.HistoryFrame.Toggle()
+    if not containerFrame then return end
+    if containerFrame:IsShown() then
+        ns.HistoryFrame.Hide()
+    else
+        ns.HistoryFrame.Show()
+    end
+end
+
+function ns.HistoryFrame.Refresh()
+    RefreshHistory()
+end
+
+function ns.HistoryFrame.ApplySettings()
+    if not containerFrame then return end
+    local fontPath, fontSize = GetFont()
+    containerFrame.titleBar.text:SetFont(fontPath, fontSize, "OUTLINE")
+end
+
+function ns.HistoryFrame.AddEntry(data)
+    local db = ns.Addon.db.profile
+    local maxEntries = db.history.maxEntries or 100
+
+    -- Insert at front (newest first)
+    table.insert(ns.historyData, 1, data)
+
+    -- Trim to maxEntries
+    while #ns.historyData > maxEntries do
+        table.remove(ns.historyData)
+    end
+
+    -- Refresh display if visible
+    if containerFrame and containerFrame:IsShown() then
+        RefreshHistory()
+    end
+end
+
+function ns.HistoryFrame.UpdateEntryByKey(dropKey, newData)
+    for i, data in ipairs(ns.historyData) do
+        if data.dropKey == dropKey then
+            ns.historyData[i] = newData
+            if containerFrame and containerFrame:IsShown() then
+                RefreshHistory()
+            end
+            return
+        end
+    end
+    -- Not found, treat as new
+    ns.HistoryFrame.AddEntry(newData)
+end
+
+function ns.HistoryFrame.SetEntries(entries)
+    local db = ns.Addon.db.profile
+    local maxEntries = db.history.maxEntries or 100
+
+    -- Replace all data
+    wipe(ns.historyData)
+    for i, entry in ipairs(entries) do
+        if i > maxEntries then break end
+        ns.historyData[i] = entry
+    end
+
+    -- Refresh display if visible
+    if containerFrame and containerFrame:IsShown() then
+        RefreshHistory()
+    end
+end
+
+function ns.HistoryFrame.ClearHistory()
+    wipe(ns.historyData)
+    if containerFrame and containerFrame:IsShown() then
+        RefreshHistory()
+    end
+end

--- a/DragonLoot.toc
+++ b/DragonLoot.toc
@@ -29,21 +29,26 @@ Display\LootAnimations.lua
 Display\RollFrame.lua
 Display\RollAnimations.lua
 Display\RollManager.lua
+Display\HistoryFrame.lua
 
 # Version-specific listeners
 #@retail@
 Listeners\LootListener_Retail.lua
 Listeners\RollListener_Retail.lua
+Listeners\HistoryListener_Retail.lua
 #@end-retail@
 #@tbc-anniversary@
 Listeners\LootListener_Classic.lua
 Listeners\RollListener_Classic.lua
+Listeners\HistoryListener_Classic.lua
 #@end-tbc-anniversary@
 #@version-mists@
 Listeners\LootListener_Classic.lua
 Listeners\RollListener_Classic.lua
+Listeners\HistoryListener_Classic.lua
 #@end-version-mists@
 #@version-cata@
 Listeners\LootListener_Classic.lua
 Listeners\RollListener_Classic.lua
+Listeners\HistoryListener_Classic.lua
 #@end-version-cata@

--- a/Listeners/HistoryListener_Retail.lua
+++ b/Listeners/HistoryListener_Retail.lua
@@ -1,0 +1,185 @@
+-------------------------------------------------------------------------------
+-- HistoryListener_Retail.lua
+-- Loot history event handling for Retail using encounter-based C_LootHistory
+--
+-- Supported versions: Retail
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Version guard: only run on Retail
+-------------------------------------------------------------------------------
+
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local C_LootHistory = C_LootHistory
+local GetItemInfoInstant = GetItemInfoInstant
+local GetItemInfo = GetItemInfo
+local GetTime = GetTime
+
+-------------------------------------------------------------------------------
+-- State
+-------------------------------------------------------------------------------
+
+local addon
+local processedDrops = {}
+
+-------------------------------------------------------------------------------
+-- Item texture helper
+-------------------------------------------------------------------------------
+
+local function GetItemTexture(itemLink)
+    if not itemLink then return nil end
+    if GetItemInfoInstant then
+        local _, _, _, _, icon = GetItemInfoInstant(itemLink)
+        return icon
+    end
+    local _, _, _, _, _, _, _, _, _, icon = GetItemInfo(itemLink)
+    return icon
+end
+
+-------------------------------------------------------------------------------
+-- Item quality helper
+-------------------------------------------------------------------------------
+
+local function GetItemQuality(itemLink)
+    if not itemLink then return 1 end
+    local _, _, quality = GetItemInfo(itemLink)
+    return quality or 1
+end
+
+-------------------------------------------------------------------------------
+-- Roll state conversion
+-- Retail C_LootHistory uses enumerated roll states that differ from classic
+-------------------------------------------------------------------------------
+
+local ROLL_STATE_MAP = {
+    [0] = 1,  -- NeedMainSpec -> Need
+    [1] = 1,  -- NeedOffSpec -> Need
+    [2] = 2,  -- Transmog -> Greed
+    [3] = 2,  -- Greed
+    [4] = 0,  -- NoRoll -> Pass
+    [5] = 0,  -- Pass
+}
+
+local function ConvertRollState(state)
+    if state == nil then return nil end
+    return ROLL_STATE_MAP[state] or 0
+end
+
+-------------------------------------------------------------------------------
+-- Process a single drop into a history entry
+-------------------------------------------------------------------------------
+
+local function ProcessDrop(encounterID, drop)
+    if not drop then return end
+
+    local itemLink = drop.itemHyperlink
+    if not itemLink then return end
+
+    local dropKey = encounterID .. "-" .. drop.lootListID
+
+    local winner = drop.winner
+    local leader = drop.currentLeader
+
+    local entry = {
+        itemLink = itemLink,
+        itemTexture = GetItemTexture(itemLink),
+        quality = GetItemQuality(itemLink),
+        winner = winner and winner.playerName or nil,
+        winnerClass = winner and winner.playerClass or nil,
+        rollType = leader and ConvertRollState(leader.state) or nil,
+        roll = leader and leader.roll or nil,
+        timestamp = GetTime(),
+        isComplete = drop.allPassed or (winner ~= nil),
+        encounterID = encounterID,
+        dropKey = dropKey,
+    }
+
+    if processedDrops[dropKey] then
+        -- Already tracked - update existing entry
+        ns.HistoryFrame.UpdateEntryByKey(dropKey, entry)
+    else
+        processedDrops[dropKey] = true
+        ns.HistoryFrame.AddEntry(entry)
+    end
+
+    local db = ns.Addon.db.profile
+    if db.history.autoShow then
+        ns.HistoryFrame.Show()
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Event handlers
+-------------------------------------------------------------------------------
+
+local function OnHistoryUpdateEncounter(_, encounterID)
+    if not encounterID then return end
+    -- Drops arrive individually via LOOT_HISTORY_UPDATE_DROP; just refresh display
+    ns.HistoryFrame.Refresh()
+    ns.DebugPrint("LOOT_HISTORY_UPDATE_ENCOUNTER: " .. tostring(encounterID))
+end
+
+local function OnHistoryUpdateDrop(_, encounterID, lootListID)
+    if not encounterID or not lootListID then return end
+    local dropInfo = C_LootHistory.GetSortedInfoForDrop(encounterID, lootListID)
+    ProcessDrop(encounterID, dropInfo)
+    ns.DebugPrint("LOOT_HISTORY_UPDATE_DROP: encounter="
+        .. tostring(encounterID) .. " drop=" .. tostring(lootListID))
+end
+
+local function OnHistoryClear()
+    wipe(processedDrops)
+    ns.HistoryFrame.ClearHistory()
+    ns.DebugPrint("LOOT_HISTORY_CLEAR_HISTORY")
+end
+
+-------------------------------------------------------------------------------
+-- Populate existing history on load
+-------------------------------------------------------------------------------
+
+local function PopulateExistingHistory()
+    if not C_LootHistory.GetAllEncounterInfos then return end
+    local encounters = C_LootHistory.GetAllEncounterInfos()
+    if not encounters then return end
+    for _, encounter in ipairs(encounters) do
+        local drops = C_LootHistory.GetSortedDropsForEncounter(encounter.encounterID)
+        if drops then
+            for _, drop in ipairs(drops) do
+                ProcessDrop(encounter.encounterID, drop)
+            end
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface: ns.HistoryListener
+-------------------------------------------------------------------------------
+
+function ns.HistoryListener.Initialize(addonRef)
+    addon = addonRef
+
+    addon:RegisterEvent("LOOT_HISTORY_UPDATE_ENCOUNTER", OnHistoryUpdateEncounter)
+    addon:RegisterEvent("LOOT_HISTORY_UPDATE_DROP", OnHistoryUpdateDrop)
+    addon:RegisterEvent("LOOT_HISTORY_CLEAR_HISTORY", OnHistoryClear)
+
+    PopulateExistingHistory()
+
+    ns.DebugPrint("Retail History Listener initialized")
+end
+
+function ns.HistoryListener.Shutdown()
+    if addon then
+        addon:UnregisterEvent("LOOT_HISTORY_UPDATE_ENCOUNTER")
+        addon:UnregisterEvent("LOOT_HISTORY_UPDATE_DROP")
+        addon:UnregisterEvent("LOOT_HISTORY_CLEAR_HISTORY")
+    end
+
+    ns.DebugPrint("Retail History Listener shut down")
+end


### PR DESCRIPTION
## Loot History (Phase 4)

Adds a scrollable loot history frame that tracks recent loot drops across encounters.

### New Files
- **Display/HistoryFrame.lua** - Scrollable history UI with entry pool, class-colored winners, quality-colored items, time-ago display, tooltips, click-to-link, custom ScrollFrame+Slider, 10-second auto-refresh
- **Listeners/HistoryListener_Retail.lua** - Encounter-based C_LootHistory with processedDrops dedup
- **Listeners/HistoryListener_Classic.lua** - Roll-item indexed C_LootHistory, mirrors API as source of truth

### Modified Files
- **Core/Init.lua** - Added ns.HistoryListener reference
- **Core/SlashCommands.lua** - Added /dl history command
- **DragonLoot.toc** - Added new files to load order
- **.luacheckrc** - Added new globals for history APIs

### Design Decisions
- Retail uses encounter-based API (GetAllEncounterInfos, GetSortedDropsForEncounter, GetSortedInfoForDrop) with dedup via processedDrops table
- Classic (TBC/MoP/Cata) uses roll-item indexed API (GetNumItems, GetItem, GetPlayerInfo)
- Entry pool pattern matches LootFrame and RollFrame for consistency
- Time-ago display refreshes every 10 seconds via AceTimer
- Supports autoShow config option

Luacheck: 0 warnings / 0 errors