### PR TITLE
feat: configurable roll-won notifications with group member support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ DragonLoot integrates with DragonToast (sibling addon) via AceEvent inter-addon 
 |---------|---------|------|
 | `DRAGONLOOT_LOOT_OPENED` | none | Loot window opens |
 | `DRAGONLOOT_LOOT_CLOSED` | none | Loot window closes |
-| `DRAGONLOOT_ROLL_WON` | `{ itemLink, itemName, itemQuality, itemIcon, quantity, rollType }` | Player wins a roll |
+| `DRAGONLOOT_ROLL_WON` | `{ itemLink, itemName, itemQuality, itemIcon, itemID, quantity, rollType, rollValue, winnerName, winnerClass, isSelf }` | A player wins a roll |
 
 ### DragonToast Behavior
 

--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -59,6 +59,10 @@ local defaults = {
             closeDuration = 0.5,
         },
 
+        rollWon = {
+            showGroupWins = false,
+        },
+
     },
 }
 
@@ -338,6 +342,19 @@ local function BuildLootRollOptions(db)
                 ns.RollManager.ApplySettings()
             end
         end,
+    }
+    args.headerRollWon = {
+        name = "Roll Won Notifications",
+        type = "header",
+        order = 10,
+    }
+    args.showGroupWins = {
+        name = "Show Group Roll Wins",
+        desc = "Show DragonToast celebration toasts when any group member wins a roll, not just you.",
+        type = "toggle",
+        order = 11,
+        get = function() return db.rollWon.showGroupWins end,
+        set = function(_, val) db.rollWon.showGroupWins = val end,
     }
     return {
         name = "Loot Roll",

--- a/Listeners/RollListener_Retail.lua
+++ b/Listeners/RollListener_Retail.lua
@@ -20,6 +20,8 @@ if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
 local GetActiveLootRollIDs = GetActiveLootRollIDs
 local GetLootRollTimeLeft = GetLootRollTimeLeft
 local StaticPopup_Show = StaticPopup_Show
+local C_LootHistory = C_LootHistory
+local C_Timer = C_Timer
 
 -------------------------------------------------------------------------------
 -- State
@@ -40,6 +42,8 @@ end
 
 local function OnCancelLootRoll(_, rollID)
     if not isRollActive then return end
+    local rolls = ns.RollManager.GetActiveRolls()
+    if rolls[rollID] and rolls[rollID].completing then return end
     ns.RollManager.CancelRoll(rollID)
     ns.DebugPrint("CANCEL_LOOT_ROLL: rollID=" .. tostring(rollID))
 end
@@ -59,8 +63,15 @@ end
 
 local function OnLootRollsComplete(_, lootHandle)
     if not isRollActive then return end
+    -- Note: LOOT_ROLLS_COMPLETE provides lootHandle which appears to match rollID from
+    -- START_LOOT_ROLL in practice. If they ever diverge, a mapping will be needed.
     ns.RollManager.OnRollComplete(lootHandle)
     ns.DebugPrint("LOOT_ROLLS_COMPLETE: handle=" .. tostring(lootHandle))
+end
+
+local function OnLootItemRollWon(_, itemLink, _rollQuantity, rollType, rollValue)
+    if not isRollActive then return end
+    ns.RollManager.OnLootItemRollWon(itemLink, rollType, rollValue)
 end
 
 -------------------------------------------------------------------------------
@@ -85,6 +96,37 @@ local function RecoverActiveRolls()
 end
 
 -------------------------------------------------------------------------------
+-- Winner resolution via C_LootHistory (for group member wins)
+-------------------------------------------------------------------------------
+
+local function ResolveWinnerFromHistory(rollID)
+    local roll = ns.RollManager.GetActiveRolls()[rollID]
+    if not roll or not roll.itemLink then return end
+
+    local encounters = C_LootHistory and C_LootHistory.GetAllEncounterInfos
+        and C_LootHistory.GetAllEncounterInfos()
+    if not encounters then return end
+
+    for i = #encounters, 1, -1 do
+        local encounter = encounters[i]
+        local drops = C_LootHistory.GetSortedDropsForEncounter(encounter.encounterID)
+        for _, drop in ipairs(drops or {}) do
+            if drop and drop.itemHyperlink == roll.itemLink and drop.winner then
+                local leader = drop.currentLeader
+                ns.RollManager.NotifyRollWinner(
+                    rollID,
+                    drop.winner.playerName,
+                    drop.winner.playerClass,
+                    leader and leader.state or nil,
+                    leader and leader.roll or nil
+                )
+                return
+            end
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Public Interface: ns.RollListener
 -------------------------------------------------------------------------------
 
@@ -98,6 +140,7 @@ function ns.RollListener.Initialize(addonRef)
     addon:RegisterEvent("CONFIRM_LOOT_ROLL", OnConfirmRoll)
     addon:RegisterEvent("CONFIRM_DISENCHANT_ROLL", OnConfirmRoll)
     addon:RegisterEvent("LOOT_ROLLS_COMPLETE", OnLootRollsComplete)
+    addon:RegisterEvent("LOOT_ITEM_ROLL_WON", OnLootItemRollWon)
 
     RecoverActiveRolls()
 
@@ -114,7 +157,14 @@ function ns.RollListener.Shutdown()
         addon:UnregisterEvent("CONFIRM_LOOT_ROLL")
         addon:UnregisterEvent("CONFIRM_DISENCHANT_ROLL")
         addon:UnregisterEvent("LOOT_ROLLS_COMPLETE")
+        addon:UnregisterEvent("LOOT_ITEM_ROLL_WON")
     end
 
     ns.DebugPrint("Retail Roll Listener shut down")
+end
+
+function ns.RollListener.ResolveWinner(rollID)
+    C_Timer.After(0.3, function()
+        ResolveWinnerFromHistory(rollID)
+    end)
 end


### PR DESCRIPTION
## Roll-Won Enhancement

Fixes several issues with roll-won messaging and adds support for group member win notifications.

### Bug Fixes
- **BLOCKER**: Fixed race condition where CANCEL_LOOT_ROLL destroyed roll data before async ResolveWinner could run (added completing flag)
- **HIGH**: Fixed duplicate-item matching - skip already-notified rollIDs when matching by itemLink
- **HIGH**: Fixed notifiedRolls memory leak - now cleared in CancelAllRolls
- **MEDIUM**: Retail ResolveWinnerFromHistory now extracts rollType/rollValue from drop.currentLeader
- Fixed roll.playerRollType always being nil - now populated from LOOT_ITEM_ROLL_WON event and C_LootHistory

### New Features
- Configurable roll-won scope: self only (default) or all group members
- Accurate winner tracking via C_LootHistory (0.3s delay for API population)
- Enhanced DRAGONLOOT_ROLL_WON payload: now includes winnerName, winnerClass, rollType, rollValue, isSelf

### Architecture
- LOOT_ITEM_ROLL_WON provides immediate local player win data
- C_LootHistory query (via ResolveWinner) provides group member win data
- notifiedRolls dedup prevents double-notification when both sources find the same winner
- completing flag on activeRolls prevents premature cleanup during async resolution
- OnLootItemRollWon shared in RollManager (DRY across listeners)

### Config
- New: rollWon.showGroupWins (default: false) - show toasts when any group member wins

### Files Changed
- Display/RollManager.lua - reworked winner notification system
- Listeners/RollListener_Retail.lua - LOOT_ITEM_ROLL_WON, ResolveWinner, completing guard
- Listeners/RollListener_Classic.lua - same
- Core/Config.lua - rollWon config group
- AGENTS.md - updated payload documentation

Luacheck: 0 warnings / 0 errors