### PR TITLE
feat: migrate to generic DragonToast messaging API

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -59,7 +59,8 @@ local defaults = {
             closeDuration = 0.5,
         },
 
-        rollWon = {
+        rollNotifications = {
+            showRollWon = true,
             showGroupWins = false,
         },
 
@@ -70,7 +71,7 @@ local defaults = {
 -- Profile Migration
 -------------------------------------------------------------------------------
 
-local CURRENT_SCHEMA = 2
+local CURRENT_SCHEMA = 1
 
 local function FillMissingDefaults(profile)
     for section, sectionDefaults in pairs(defaults.profile) do
@@ -93,10 +94,6 @@ local function MigrateProfile(db)
 
     if version < 1 then
         FillMissingDefaults(profile)
-    end
-
-    if version < 2 then
-        profile.sound = nil
     end
 
     profile.schemaVersion = CURRENT_SCHEMA
@@ -348,13 +345,23 @@ local function BuildLootRollOptions(db)
         type = "header",
         order = 10,
     }
-    args.showGroupWins = {
-        name = "Show Group Roll Wins",
-        desc = "Show DragonToast celebration toasts when any group member wins a roll, not just you.",
+    args.showRollWon = {
+        name = "Show Roll Won Toasts",
+        desc = "Send a DragonToast notification when you win a loot roll.",
         type = "toggle",
         order = 11,
-        get = function() return db.rollWon.showGroupWins end,
-        set = function(_, val) db.rollWon.showGroupWins = val end,
+        width = "full",
+        get = function() return db.rollNotifications.showRollWon end,
+        set = function(_, val) db.rollNotifications.showRollWon = val end,
+    }
+    args.showGroupWins = {
+        name = "Show Group Roll Wins",
+        desc = "Also show DragonToast notifications when other group members win rolls.",
+        type = "toggle",
+        order = 12,
+        get = function() return db.rollNotifications.showGroupWins end,
+        set = function(_, val) db.rollNotifications.showGroupWins = val end,
+        disabled = function() return not db.rollNotifications.showRollWon end,
     }
     return {
         name = "Loot Roll",

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -189,12 +189,7 @@ function Addon:OnEnable()
     if ns.HistoryListener.Initialize then ns.HistoryListener.Initialize(self) end
     if ns.Listeners.Initialize then ns.Listeners.Initialize(self) end
 
-    -- DragonToast integration
-    local IsAddOnLoadedFn = C_AddOns and C_AddOns.IsAddOnLoaded or IsAddOnLoaded
-    ns.hasDragonToast = IsAddOnLoadedFn("DragonToast") or false
-    if ns.hasDragonToast then
-        ns.DebugPrint("DragonToast detected - cross-addon messaging enabled")
-    end
+
 end
 
 function Addon:OnDisable()

--- a/Listeners/LootListener_Classic.lua
+++ b/Listeners/LootListener_Classic.lua
@@ -34,8 +34,8 @@ local function OnLootOpened(_, autoLoot)
     ns.SuppressBlizzardLootFrame()
     ns.LootFrame.Show(autoLoot)
 
-    -- Message hook for Roll/History modules (Phase 3/4)
-    ns.Addon:SendMessage("DRAGONLOOT_LOOT_OPENED")
+    -- Suppress DragonToast item toasts while loot window is open
+    ns.Addon:SendMessage("DRAGONTOAST_SUPPRESS", "DragonLoot")
     ns.DebugPrint("LOOT_OPENED fired (Classic)")
 end
 
@@ -55,8 +55,8 @@ local function OnLootClosed()
         isLootOpen = false
         ns.LootFrame.Hide()
 
-        -- Message hook for Roll/History modules (Phase 3/4)
-        ns.Addon:SendMessage("DRAGONLOOT_LOOT_CLOSED")
+        -- Resume DragonToast item toasts
+        ns.Addon:SendMessage("DRAGONTOAST_UNSUPPRESS", "DragonLoot")
         ns.DebugPrint("LOOT_CLOSED fired (Classic)")
     end
 end

--- a/Listeners/LootListener_Retail.lua
+++ b/Listeners/LootListener_Retail.lua
@@ -42,8 +42,8 @@ local function OnLootReady()
     ns.SuppressBlizzardLootFrame()
     ns.LootFrame.Show(pendingAutoLoot)
 
-    -- Message hook for Roll/History modules (Phase 3/4)
-    ns.Addon:SendMessage("DRAGONLOOT_LOOT_OPENED")
+    -- Suppress DragonToast item toasts while loot window is open
+    ns.Addon:SendMessage("DRAGONTOAST_SUPPRESS", "DragonLoot")
     ns.DebugPrint("LOOT_READY fired (Retail)")
 end
 
@@ -64,8 +64,8 @@ local function OnLootClosed()
         pendingAutoLoot = false
         ns.LootFrame.Hide()
 
-        -- Message hook for Roll/History modules (Phase 3/4)
-        ns.Addon:SendMessage("DRAGONLOOT_LOOT_CLOSED")
+        -- Resume DragonToast item toasts
+        ns.Addon:SendMessage("DRAGONTOAST_UNSUPPRESS", "DragonLoot")
         ns.DebugPrint("LOOT_CLOSED fired (Retail)")
     end
 end


### PR DESCRIPTION
## Summary

Migrates DragonLoot from addon-specific AceEvent messages to the generic DragonToast messaging API and resets the schema to a clean slate.

### Changes
- **Config.lua** - Replace `rollWon` with `rollNotifications`, add `showRollWon` toggle, reset schema to v1
- **Init.lua** - Remove `ns.hasDragonToast` detection (fire-and-forget API needs no detection)
- **RollManager.lua** - Send `DRAGONTOAST_QUEUE_TOAST` instead of `DRAGONLOOT_ROLL_WON`, add roll type name constants
- **LootListener_Retail.lua** - Send `DRAGONTOAST_SUPPRESS`/`UNSUPPRESS` instead of `DRAGONLOOT_LOOT_OPENED`/`CLOSED`
- **LootListener_Classic.lua** - Same migration as Retail
- **AGENTS.md** - Updated messaging documentation for generic API

### Generic Messages
| Old Message | New Message |
|---|---|
| `DRAGONLOOT_LOOT_OPENED` | `DRAGONTOAST_SUPPRESS` with source `"DragonLoot"` |
| `DRAGONLOOT_LOOT_CLOSED` | `DRAGONTOAST_UNSUPPRESS` with source `"DragonLoot"` |
| `DRAGONLOOT_ROLL_WON` | `DRAGONTOAST_QUEUE_TOAST` with toast data table |