### PR TITLE
fix: restructure TOC to eliminate duplicate listener file loads

### DIFF
--- a/DragonLoot.toc
+++ b/DragonLoot.toc
@@ -31,24 +31,13 @@ Display\RollAnimations.lua
 Display\RollManager.lua
 Display\HistoryFrame.lua
 
-# Version-specific listeners
+# Version-specific listeners (Classic loads as default, Retail overrides via packager)
+Listeners\LootListener_Classic.lua
+Listeners\RollListener_Classic.lua
+Listeners\HistoryListener_Classic.lua
+
 #@retail@
 Listeners\LootListener_Retail.lua
 Listeners\RollListener_Retail.lua
 Listeners\HistoryListener_Retail.lua
 #@end-retail@
-#@tbc-anniversary@
-Listeners\LootListener_Classic.lua
-Listeners\RollListener_Classic.lua
-Listeners\HistoryListener_Classic.lua
-#@end-tbc-anniversary@
-#@version-mists@
-Listeners\LootListener_Classic.lua
-Listeners\RollListener_Classic.lua
-Listeners\HistoryListener_Classic.lua
-#@end-version-mists@
-#@version-cata@
-Listeners\LootListener_Classic.lua
-Listeners\RollListener_Classic.lua
-Listeners\HistoryListener_Classic.lua
-#@end-version-cata@


### PR DESCRIPTION
Fixes LUA_WARNING duplicate file load warnings when running locally.

**Problem:** The TOC had 4 packager directive blocks (`#@retail@`, `#@tbc-anniversary@`, `#@version-mists@`, `#@version-cata@`). Locally, all directives are comments, so Classic listeners loaded 3 times (once per Classic block), producing duplicate file warnings.

**Fix:** Load Classic listeners unconditionally as the default (outside any directive), and wrap only Retail listeners in `#@retail@`. Locally, Classic loads first, then Retail overrides - no duplicates. In packaged builds, the packager strips `#@retail@` for Classic flavors.

This follows the root AGENTS.md guidance: *Packager directives are comments locally, so later files can override earlier ones.*