### PR TITLE
fix: profile reset refresh, toast suppression, roll frame width

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -960,10 +960,23 @@ function ns.InitializeDB(addon)
     -- Migrate active profile
     MigrateProfile(addon.db)
 
-    -- Re-migrate on profile changes
-    addon.db.RegisterCallback(addon, "OnProfileChanged", function() MigrateProfile(addon.db) end)
-    addon.db.RegisterCallback(addon, "OnProfileCopied", function() MigrateProfile(addon.db) end)
-    addon.db.RegisterCallback(addon, "OnProfileReset", function() ResetToDefaults(addon.db.profile) end)
+    -- Re-migrate on profile changes and refresh UI
+    local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
+    addon.db.RegisterCallback(addon, "OnProfileChanged", function()
+        MigrateProfile(addon.db)
+        NotifyAppearanceChange()
+        AceConfigRegistry:NotifyChange(ADDON_NAME)
+    end)
+    addon.db.RegisterCallback(addon, "OnProfileCopied", function()
+        MigrateProfile(addon.db)
+        NotifyAppearanceChange()
+        AceConfigRegistry:NotifyChange(ADDON_NAME)
+    end)
+    addon.db.RegisterCallback(addon, "OnProfileReset", function()
+        ResetToDefaults(addon.db.profile)
+        NotifyAppearanceChange()
+        AceConfigRegistry:NotifyChange(ADDON_NAME)
+    end)
 
     -- Register options
     AceConfig:RegisterOptionsTable(ADDON_NAME, GetOptions)

--- a/Display/RollFrame.lua
+++ b/Display/RollFrame.lua
@@ -86,7 +86,7 @@ local PASS_ICON = "Interface\\Buttons\\UI-GroupLoot-Pass-Up"
 -- Frame dimensions
 -------------------------------------------------------------------------------
 
-local FRAME_WIDTH = 280
+local FRAME_WIDTH = 328
 local FRAME_BASE_HEIGHT = 54
 local BUTTON_SIZE = 24
 local FRAME_SPACING = 4
@@ -170,9 +170,9 @@ local function ApplyLayoutOffsets(frame)
     frame.itemName:SetPoint("TOPLEFT", frame.iconFrame, "TOPRIGHT", 6, -1)
     frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(4 + borderSize), 0)
 
-    -- BoP indicator
+    -- BoP indicator - anchored below item name, clear of roll buttons
     frame.bindText:ClearAllPoints()
-    frame.bindText:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -(4 + borderSize), -(2 + borderSize))
+    frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -1)
 
     -- Timer bar
     frame.timerBar:ClearAllPoints()
@@ -422,7 +422,7 @@ local function CreateRollFrame(index)
 
     -- BoP indicator
     frame.bindText = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    frame.bindText:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -4, -2)
+    frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -1)
     frame.bindText:SetTextColor(1, 0.2, 0.2)
     frame.bindText:Hide()
 
@@ -811,10 +811,6 @@ end
 function ns.RollFrame.ApplySettings()
     if not anchorFrame then return end
     local db = ns.Addon.db.profile
-    if not db then return end
-    local rollFrameDb = db.rollFrame or {}
-    local appearance = db.appearance or {}
-
     if not db then return end
 
     local appearance = db.appearance or {}


### PR DESCRIPTION
## Fixes

### 1. Profile reset/switch doesn't refresh UI (Critical)
Profile change callbacks now call NotifyAppearanceChange() and AceConfigRegistry:NotifyChange() so open frames and the config panel immediately reflect the new profile's settings.

### 2. Loot toast suppression during auto-loot (Critical)
DRAGONTOAST_SUPPRESS is now only sent when the loot frame is actually displayed (skipped during auto-loot). Hide() is wrapped in pcall so UNSUPPRESS always fires even if Hide errors. isLootOpen is now set after the enabled check to prevent calling Hide on frames that were never shown.

### 3. Roll frame BoP text overlapping buttons (Major)
Increased FRAME_WIDTH from 280 to 328. Moved bindText anchor from TOPRIGHT (overlapping roll buttons) to below the item name text.

### 4. Duplicate variables in RollFrame.ApplySettings (Minor)
Removed duplicate variable declarations and redundant nil check.