### PR TITLE
fix: suppress Blizzard roll frames via UIParent and convert roll timer from ms to seconds

### DIFF
--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -111,6 +111,12 @@ local function SuppressBlizzardLootFrame()
 end
 
 local function SuppressBlizzardRollFrames()
+    -- UIParent is the primary dispatch: it receives START_LOOT_ROLL and calls
+    -- GroupLootContainer_AddRoll(), which re-shows GroupLootFrame1-4.
+    UIParent:UnregisterEvent("START_LOOT_ROLL")
+    UIParent:UnregisterEvent("CANCEL_LOOT_ROLL")
+
+    -- Belt-and-suspenders: also suppress the individual roll frames and container
     for i = 1, 4 do
         local frame = _G["GroupLootFrame" .. i]
         if frame then
@@ -134,6 +140,10 @@ local function RestoreBlizzardLootFrame()
 end
 
 local function RestoreBlizzardRollFrames()
+    -- Restore UIParent dispatch so Blizzard roll frames work again
+    UIParent:RegisterEvent("START_LOOT_ROLL")
+    UIParent:RegisterEvent("CANCEL_LOOT_ROLL")
+
     for i = 1, 4 do
         local frame = _G["GroupLootFrame" .. i]
         if frame then

--- a/Listeners/RollListener_Classic.lua
+++ b/Listeners/RollListener_Classic.lua
@@ -36,8 +36,10 @@ local isRollActive = false
 
 local function OnStartLootRoll(_, rollID, rollTime)
     if not isRollActive then return end
-    ns.RollManager.StartRoll(rollID, rollTime)
-    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTime))
+    -- Classic passes rollTime in milliseconds; convert to seconds for RollManager
+    local rollTimeSec = rollTime / 1000
+    ns.RollManager.StartRoll(rollID, rollTimeSec)
+    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTimeSec) .. "s")
 end
 
 local function OnCancelLootRoll(_, rollID)
@@ -77,8 +79,10 @@ local function RecoverActiveRolls()
     local activeRollIDs = GetActiveLootRollIDs()
     if not activeRollIDs then return end
     for _, rollID in ipairs(activeRollIDs) do
-        local timeLeft = GetLootRollTimeLeft(rollID)
-        if timeLeft and timeLeft > 0 then
+        local timeLeftMs = GetLootRollTimeLeft(rollID)
+        if timeLeftMs and timeLeftMs > 0 then
+            -- Classic returns milliseconds; convert to seconds for RollManager
+            local timeLeft = timeLeftMs / 1000
             ns.RollManager.RecoverRoll(rollID, timeLeft, timeLeft)
         end
     end

--- a/Listeners/RollListener_Retail.lua
+++ b/Listeners/RollListener_Retail.lua
@@ -36,8 +36,10 @@ local isRollActive = false
 
 local function OnStartLootRoll(_, rollID, rollTime)
     if not isRollActive then return end
-    ns.RollManager.StartRoll(rollID, rollTime)
-    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTime))
+    -- Retail passes rollTime in milliseconds; convert to seconds for RollManager
+    local rollTimeSec = rollTime / 1000
+    ns.RollManager.StartRoll(rollID, rollTimeSec)
+    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTimeSec) .. "s")
 end
 
 local function OnCancelLootRoll(_, rollID)
@@ -86,11 +88,14 @@ local function RecoverActiveRolls()
 
     local GetRollDuration = C_Loot and C_Loot.GetLootRollDuration
     for _, rollID in ipairs(activeRollIDs) do
-        local timeLeft = GetLootRollTimeLeft(rollID)
-        if timeLeft and timeLeft > 0 then
-            local totalDuration = GetRollDuration and GetRollDuration(rollID) or timeLeft
-            ns.RollManager.RecoverRoll(rollID, totalDuration or timeLeft, timeLeft)
-            ns.DebugPrint("Recovered active roll: " .. tostring(rollID))
+        local timeLeftMs = GetLootRollTimeLeft(rollID)
+        if timeLeftMs and timeLeftMs > 0 then
+            local totalDurationMs = GetRollDuration and GetRollDuration(rollID) or timeLeftMs
+            -- Retail returns milliseconds; convert to seconds for RollManager
+            local totalDuration = (totalDurationMs or timeLeftMs) / 1000
+            local timeLeft = timeLeftMs / 1000
+            ns.RollManager.RecoverRoll(rollID, totalDuration, timeLeft)
+            ns.DebugPrint("Recovered active roll: " .. tostring(rollID) .. " (" .. tostring(timeLeft) .. "s left)")
         end
     end
 end


### PR DESCRIPTION
## Summary
Two roll frame bugs fixed:
1. **Blizzard roll frames not suppressed** - Both DragonLoot and Blizzard roll frames were showing simultaneously because `UIParent` dispatches `START_LOOT_ROLL` to `GroupLootContainer_AddRoll()`, re-showing Blizzard frames even after DragonLoot suppressed them.
2. **Timer counting down from ~50000+ seconds** - `START_LOOT_ROLL` passes `rollTime` in milliseconds on both Retail and Classic. `RollManager` uses `GetTime()` (seconds) for elapsed time, causing a unit mismatch.
## Changes
### Core/Init.lua
- `SuppressBlizzardRollFrames()` now unregisters `START_LOOT_ROLL` and `CANCEL_LOOT_ROLL` from `UIParent` (the primary dispatch mechanism)
- `RestoreBlizzardRollFrames()` re-registers both events on disable
- Existing GroupLootFrame1-4 and GroupLootContainer suppression kept as belt-and-suspenders
### Listeners/RollListener_Retail.lua
- `OnStartLootRoll`: converts `rollTime` from ms to seconds before passing to RollManager
- `RecoverActiveRolls`: converts `GetLootRollTimeLeft()` and `C_Loot.GetLootRollDuration()` from ms to seconds
### Listeners/RollListener_Classic.lua
- `OnStartLootRoll`: converts `rollTime` from ms to seconds before passing to RollManager
- `RecoverActiveRolls`: converts `GetLootRollTimeLeft()` from ms to seconds
## Testing
- Luacheck passes on all modified files
- Conversion applied at listener boundaries only; RollManager receives clean seconds values regardless of game version
- UIParent suppression matches the pattern used by ElvUI, XLoot, and ShestakUI