### PR TITLE
fix: clarify slash command help and toggle behavior

### DIFF
--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -16,11 +16,10 @@ local strtrim = strtrim
 
 local function PrintHelp()
     print(ns.COLOR_GOLD .. "--- DragonLoot Commands ---" .. ns.COLOR_RESET)
-    print("  " .. ns.COLOR_WHITE .. "/dl" .. ns.COLOR_RESET .. " - Toggle addon on/off")
+    print("  " .. ns.COLOR_WHITE .. "/dl" .. ns.COLOR_RESET .. " - Show this help")
+    print("  " .. ns.COLOR_WHITE .. "/dl toggle" .. ns.COLOR_RESET .. " - Toggle addon on/off")
     print("  " .. ns.COLOR_WHITE .. "/dl config" .. ns.COLOR_RESET .. " - Open settings panel")
     print("  " .. ns.COLOR_WHITE .. "/dl minimap" .. ns.COLOR_RESET .. " - Toggle minimap icon")
-    print("  " .. ns.COLOR_WHITE .. "/dl enable" .. ns.COLOR_RESET .. " - Enable addon")
-    print("  " .. ns.COLOR_WHITE .. "/dl disable" .. ns.COLOR_RESET .. " - Disable addon")
     print("  " .. ns.COLOR_WHITE .. "/dl reset" .. ns.COLOR_RESET .. " - Reset loot frame position")
     print("  " .. ns.COLOR_WHITE .. "/dl test" .. ns.COLOR_RESET .. " - Show test loot")
     print("  " .. ns.COLOR_WHITE .. "/dl testroll" .. ns.COLOR_RESET .. " - Show test roll frames")
@@ -66,28 +65,12 @@ local function ToggleAddon()
     end
 end
 
-local function SetAddonEnabled(enabled)
-    local db = ns.Addon.db.profile
-    if db.enabled ~= enabled then
-        db.enabled = enabled
-        if enabled then
-            ns.Addon:OnEnable()
-        else
-            ns.Addon:OnDisable()
-        end
-    end
-    local color = enabled and ns.COLOR_GREEN or ns.COLOR_RED
-    local label = enabled and "enabled" or "disabled"
-    ns.Print("Addon " .. color .. label .. ns.COLOR_RESET)
-end
-
 local commandHandlers = {
     ["config"]   = function() if ns.ToggleConfigWindow then ns.ToggleConfigWindow() end end,
     ["options"]  = function() if ns.ToggleConfigWindow then ns.ToggleConfigWindow() end end,
     ["settings"] = function() if ns.ToggleConfigWindow then ns.ToggleConfigWindow() end end,
     ["minimap"]  = function() if ns.MinimapIcon.Toggle then ns.MinimapIcon.Toggle() end end,
-    ["enable"]   = function() SetAddonEnabled(true) end,
-    ["disable"]  = function() SetAddonEnabled(false) end,
+    ["toggle"]   = ToggleAddon,
     ["status"]   = PrintStatus,
     ["help"]     = PrintHelp,
     ["?"]        = PrintHelp,
@@ -126,7 +109,7 @@ function ns.HandleSlashCommand(input)
     local cmd = strtrim((input or ""):lower())
 
     if cmd == "" then
-        ToggleAddon()
+        PrintHelp()
         return
     end
 

--- a/README.md
+++ b/README.md
@@ -56,18 +56,22 @@
 
 ## ⌨️ Commands
 
-All commands use the `/dl` prefix (or the full `/dragonloot`):
+Use `/dl` or `/dragonloot`.
 
-| Command           | Description                    |
-|:------------------|:-------------------------------|
-| `/dl`             | Open settings                  |
-| `/dl test`        | Show test loot items           |
-| `/dl testmode`    | Toggle continuous test mode    |
-| `/dl testroll`    | Show test roll frame           |
-| `/dl clear`       | Clear all test items           |
-| `/dl history`     | Toggle loot history panel      |
-| `/dl config`      | Open settings panel            |
-| `/dl minimap`     | Toggle minimap icon            |
+Typing `/dl` by itself shows the help list. `/dl toggle` is the only slash command that turns DragonLoot on or off.
+
+| Command | What it does |
+|:--------|:-------------|
+| `/dl` | Show the help list |
+| `/dl help` | Show the help list |
+| `/dl toggle` | Turn DragonLoot on or off |
+| `/dl config` | Open the settings panel |
+| `/dl minimap` | Show or hide the minimap button |
+| `/dl reset` | Reset the loot window position |
+| `/dl test` | Show test loot |
+| `/dl testroll` | Show test roll frames |
+| `/dl history` | Open or close the loot history window |
+| `/dl status` | Show your current DragonLoot settings |
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
## Summary
- Makes DragonLoot slash commands clearer by reserving /dl for help and using an explicit toggle command.

## Changes
- Updates /dl to show the help list instead of toggling the addon.
- Adds /dl toggle as the explicit command for enabling or disabling DragonLoot.
- Removes /dl enable and /dl disable from the help flow and command handling.
- Refreshes the README command section to match the current slash command behavior.

## Testing
- GitHub Actions: luacheck
