### PR TITLE
fix: correct CHAT_MSG_LOOT guid parameter offset (#51)

### DIFF
--- a/Listeners/LootHistoryChat.lua
+++ b/Listeners/LootHistoryChat.lua
@@ -247,7 +247,7 @@ local function ProcessLootMessage(message, _, guid)
             quantity = otherQuantity
 
             -- Get class from GUID
-            if guid then
+            if type(guid) == "string" then
                 local _, englishClass = GetPlayerInfoByGUID(guid)
                 playerClass = englishClass
             end
@@ -275,7 +275,7 @@ end
 --   languageID, lineID, guid (arg12)
 -------------------------------------------------------------------------------
 
-local function OnChatMsgLoot(_, message, _, _, _, _, _, _, _, _, _, guid)
+local function OnChatMsgLoot(_, message, _, _, _, _, _, _, _, _, _, _, guid)
     ProcessLootMessage(message, nil, guid)
 end
 


### PR DESCRIPTION
## Description

Fixes an off-by-one in the `CHAT_MSG_LOOT` callback parameter list in `LootHistoryChat.lua`.

AceEvent passes the event name as the first callback argument, then the 12 `CHAT_MSG_LOOT` args follow. The callback only had 12 parameters (event + 11 args), so `guid` was bound to `lineID` (arg11, a number) instead of the actual sender GUID (arg12, a string). `GetPlayerInfoByGUID` then rejected the non-string input, producing a usage error whenever a party member looted an item.

**Changes:**
- **Line 278** - Added missing `_` placeholder before `guid` in `OnChatMsgLoot` so the parameter correctly captures `senderGUID` (arg12) instead of `lineID` (arg11)
- **Line 250** - Strengthened guard from `if guid then` to `if type(guid) == "string" then` for defense-in-depth against non-string values reaching `GetPlayerInfoByGUID`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues

Fixes #51

## Testing

- [x] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [ ] WoW version(s) tested on: TBC Anniversary (reported version)

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format