### PR TITLE
fix: add issue types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report a bug with DragonLoot
 title: "[Bug]: "
+type: "Bug"
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement for DragonLoot
 title: "[Feature]: "
+type: "Feature"
 labels:
   - enhancement
 assignees: []


### PR DESCRIPTION
## Description

Issue templates only assigned labels (`bug`, `enhancement`) but didn't set the org-level issue types. New issues created from templates were untyped despite the org having Bug, Feature, and Task types configured.

Adds `type: "Bug"` to `bug-report.yml` and `type: "Feature"` to `feature-request.yml` so issues get proper types on creation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues

N/A - housekeeping fix.

## Testing

- [ ] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [x] Verified template YAML syntax is valid

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format