### PR TITLE
fix: resolve loot window position flash and Blizzard frame leak with open-at-cursor

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,7 +29,7 @@ read_globals = {
 
     -- WoW API - General
     "CreateFrame", "GetTime", "IsInInstance", "UnitName", "UnitClass",
-    "GetItemInfo", "GetItemInfoInstant", "GetItemQualityColor",
+    "GetItemInfo", "GetItemInfoInstant", "GetItemQualityColor", "GetCursorPosition",
     "C_Timer", "C_Item", "C_Container", "C_AddOns", "IsAddOnLoaded", "LoadAddOn",
     "CreateColor",
     "GameTooltip", "UIParent", "PlaySound", "PlaySoundFile",

--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -28,6 +28,7 @@ local defaults = {
             height = 300,
             slotSpacing = 2,
             contentPadding = 4,
+            positionAtCursor = false,
         },
 
         rollFrame = {

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -104,10 +104,25 @@ local ROLL_FRAME_EVENTS = {
     "START_LOOT_ROLL", "CANCEL_LOOT_ROLL",
 }
 
+local blizzardLootHooked = false
+
 local function SuppressBlizzardLootFrame()
     if not LootFrame then return end
     LootFrame:UnregisterAllEvents()
     LootFrame:Hide()
+
+    -- Persistent OnShow hook: catches any attempt to show the Blizzard frame
+    -- (EventRegistry callbacks, re-registered events, direct Show calls).
+    -- The config check keeps the hook inert when DragonLoot's loot window is disabled.
+    if not blizzardLootHooked then
+        LootFrame:HookScript("OnShow", function(self)
+            local db = ns.Addon and ns.Addon.db and ns.Addon.db.profile
+            if db and db.lootWindow and db.lootWindow.enabled then
+                self:Hide()
+            end
+        end)
+        blizzardLootHooked = true
+    end
 end
 
 local function SuppressBlizzardRollFrames()

--- a/Display/LootAnimations.lua
+++ b/Display/LootAnimations.lua
@@ -32,8 +32,6 @@ function ns.LootAnimations.PlayOpen(frame)
     frame:SetAlpha(0)
     frame:Show()
 
-    ns.LootAnimations.StopAll(frame)
-
     local animName = db.animation.lootOpenAnim or "fadeIn"
     local ok = pcall(lib.Animate, lib, frame, animName, {
         duration = duration,

--- a/Display/LootFrame.lua
+++ b/Display/LootFrame.lua
@@ -25,6 +25,7 @@ local STANDARD_TEXT_FONT = STANDARD_TEXT_FONT
 local UNKNOWN = UNKNOWN
 local GetLootSlotLink = GetLootSlotLink
 local CreateColor = CreateColor
+local GetCursorPosition = GetCursorPosition
 
 local LSM = LibStub("LibSharedMedia-3.0")
 
@@ -283,6 +284,14 @@ local function RestoreFramePosition()
     else
         containerFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     end
+end
+
+local function PositionAtCursor()
+    if not containerFrame then return end
+    local x, y = GetCursorPosition()
+    local scale = containerFrame:GetEffectiveScale()
+    containerFrame:ClearAllPoints()
+    containerFrame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", x / scale, y / scale)
 end
 
 -------------------------------------------------------------------------------
@@ -813,6 +822,19 @@ function ns.LootFrame.Show(autoLoot)
 
     LayoutSlots()
 
+    -- Clean up any lingering animation state before positioning so that
+    -- LibAnimate's Stop() does not restore a stale anchor and undo the
+    -- cursor placement set below.
+    if ns.LootAnimations and ns.LootAnimations.StopAll then
+        ns.LootAnimations.StopAll(containerFrame)
+    end
+
+    -- Position at cursor if enabled
+    local lootDb = ns.Addon.db.profile.lootWindow
+    if lootDb.positionAtCursor then
+        PositionAtCursor()
+    end
+
     -- Fishing indicator
     if IsFishingLoot and IsFishingLoot() then
         containerFrame.fishingText:SetText("Fishing")
@@ -1118,6 +1140,16 @@ function ns.LootFrame.ShowTestLoot()
     end
 
     LayoutSlots()
+
+    -- Clean up lingering animation state before positioning (same as Show)
+    if ns.LootAnimations and ns.LootAnimations.StopAll then
+        ns.LootAnimations.StopAll(containerFrame)
+    end
+
+    local lootDb = ns.Addon.db.profile.lootWindow
+    if lootDb.positionAtCursor then
+        PositionAtCursor()
+    end
     containerFrame.fishingText:Hide()
 
     ShowWithAnimation()

--- a/DragonLoot_Options/Tabs/LootWindowTab.lua
+++ b/DragonLoot_Options/Tabs/LootWindowTab.lua
@@ -87,7 +87,22 @@ local function CreateContent(parent)
     })
     lockToggle:SetPoint("TOPLEFT", parent, "TOPLEFT", PADDING_SIDE, yOffset)
     lockToggle:SetPoint("TOPRIGHT", parent, "TOPRIGHT", -PADDING_SIDE, yOffset)
-    yOffset = yOffset - lockToggle:GetHeight() - SPACING_BETWEEN_SECTIONS
+    yOffset = yOffset - lockToggle:GetHeight() - SPACING_BETWEEN_WIDGETS
+
+    ---------------------------------------------------------------------------
+    -- Toggle: Position at Cursor
+    ---------------------------------------------------------------------------
+    local cursorToggle = W.CreateToggle(parent, {
+        label = "Position at Cursor",
+        tooltip = "Open the loot window at the mouse cursor instead of the saved position",
+        get = function() return db.profile.lootWindow.positionAtCursor end,
+        set = function(value)
+            db.profile.lootWindow.positionAtCursor = value
+        end,
+    })
+    cursorToggle:SetPoint("TOPLEFT", parent, "TOPLEFT", PADDING_SIDE, yOffset)
+    cursorToggle:SetPoint("TOPRIGHT", parent, "TOPRIGHT", -PADDING_SIDE, yOffset)
+    yOffset = yOffset - cursorToggle:GetHeight() - SPACING_BETWEEN_SECTIONS
 
     ---------------------------------------------------------------------------
     -- Header: Layout


### PR DESCRIPTION
## Description

Fixes two bugs when "Position at Cursor" is enabled:

1. **Loot window "spazzes out" before reaching cursor** - `PlayOpen()` called `StopAll()` after `PositionAtCursor()` had already set the frame's anchor. LibAnimate's `Stop()` restores the pre-animation anchor, undoing the cursor placement. The frame would briefly appear at the old/saved position before the animation started from the wrong location.

2. **Blizzard LootFrame appears alongside DragonLoot** - The existing `UnregisterAllEvents()` suppression is fragile against EventRegistry callbacks, re-registered events, or direct `Show()` calls in newer Retail builds. The Blizzard frame could flash for one or more render frames before the defensive re-suppression in the loot listener ran.

### Changes

- **Core/Init.lua**: Added a persistent `HookScript("OnShow")` on the Blizzard `LootFrame` that immediately hides it when DragonLoot's loot window is enabled. The hook is inert when the loot window is disabled, so `RestoreBlizzardLootFrame()` needs no changes.
- **Display/LootAnimations.lua**: Removed `StopAll()` from `PlayOpen()` - cleanup responsibility moves to the caller.
- **Display/LootFrame.lua**: Added `StopAll()` call before `PositionAtCursor()` in both `Show()` and `ShowTestLoot()`. This ensures the sequence is: stop old animations -> position at cursor -> start new animation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Luacheck passes with 0 warnings / 0 errors
- [ ] Tested in Retail
- [ ] Tested in Classic

### Manual Test Steps

1. Enable "Position at Cursor" in config
2. `/dl test` - verify loot window appears cleanly at cursor with no flash at saved position
3. Loot a mob - verify DragonLoot frame at cursor, no Blizzard frame visible
4. Chain-kill mobs rapidly (close animation still playing when next loot opens) - no position flash
5. Disable DragonLoot's loot window in config - verify Blizzard frame works normally
6. Toggle animations off - loot window should still open at cursor cleanly
7. Change animation type to slideInRight - verify slide starts from near cursor

## Checklist

- [x] Code follows the project's style guidelines
- [x] No new warnings from luacheck
- [x] Self-reviewed the changes
- [x] No unrelated changes included