### PR TITLE
fix: robust Blizzard loot frame suppression on Retail

### DIFF
--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -7,6 +7,8 @@
 
 local ADDON_NAME, ns = ...
 
+local hooksecurefunc = hooksecurefunc
+
 -------------------------------------------------------------------------------
 -- Constants
 -------------------------------------------------------------------------------
@@ -107,10 +109,26 @@ local ROLL_FRAME_EVENTS = {
     "START_LOOT_ROLL", "CANCEL_LOOT_ROLL",
 }
 
+local lootFrameHooked = false
+
 local function SuppressBlizzardLootFrame()
     if not LootFrame then return end
     LootFrame:UnregisterAllEvents()
     LootFrame:Hide()
+
+    -- One-time hook: catches any code path that calls LootFrame:Show()
+    -- (e.g. Blizzard event dispatch race, LoD addon re-showing the frame).
+    -- The hook is permanent but config-gated, so it becomes a no-op when
+    -- the custom loot window is disabled.
+    if not lootFrameHooked then
+        hooksecurefunc(LootFrame, "Show", function(self)
+            local db = ns.Addon.db and ns.Addon.db.profile
+            if db and db.lootWindow and db.lootWindow.enabled then
+                self:Hide()
+            end
+        end)
+        lootFrameHooked = true
+    end
 end
 
 local function SuppressBlizzardRollFrames()
@@ -197,6 +215,17 @@ function Addon:OnEnable()
     -- Suppress Blizzard frames when our replacement is enabled
     if db.lootWindow and db.lootWindow.enabled then
         SuppressBlizzardLootFrame()
+
+        -- If LootFrame doesn't exist yet (Blizzard LoD addon not loaded),
+        -- watch ADDON_LOADED and suppress as soon as it appears.
+        if not LootFrame then
+            self:RegisterEvent("ADDON_LOADED", function()
+                if LootFrame then
+                    SuppressBlizzardLootFrame()
+                    self:UnregisterEvent("ADDON_LOADED")
+                end
+            end)
+        end
     end
     if db.rollFrame and db.rollFrame.enabled then
         SuppressBlizzardRollFrames()
@@ -217,6 +246,9 @@ function Addon:OnDisable()
     -- Restore Blizzard frames
     RestoreBlizzardLootFrame()
     RestoreBlizzardRollFrames()
+
+    -- Stop watching for Blizzard LoD addon if still waiting
+    pcall(self.UnregisterEvent, self, "ADDON_LOADED")
 
     -- Shutdown modules if present
     if ns.LootFrame.Shutdown then ns.LootFrame.Shutdown() end

--- a/DragonLoot/Listeners/LootListener_Retail.lua
+++ b/DragonLoot/Listeners/LootListener_Retail.lua
@@ -29,6 +29,15 @@ local function OnLootOpened(_, autoLoot)
     -- LOOT_OPENED fires first on Retail and carries the autoLoot flag.
     -- Capture it for LOOT_READY which follows immediately after.
     pendingAutoLoot = (autoLoot == 1) or (autoLoot == true)
+
+    -- Suppress the Blizzard loot frame as early as possible. LOOT_OPENED
+    -- fires before LOOT_READY; without this, Blizzard's LootFrame processes
+    -- LOOT_OPENED and shows before OnLootReady can suppress it.
+    local db = ns.Addon.db and ns.Addon.db.profile
+    if db and db.lootWindow and db.lootWindow.enabled then
+        ns.SuppressBlizzardLootFrame()
+    end
+
     ns.DebugPrint("LOOT_OPENED captured autoLoot=" .. tostring(pendingAutoLoot))
 end
 


### PR DESCRIPTION
## Description

Fix the default Blizzard `LootFrame` showing alongside DragonLoot's custom frame on Retail by adding a three-layer suppression defense.

### Problem

The existing suppression (`UnregisterAllEvents` + `Hide`) fails on Retail because:

1. **LoD timing** - `LootFrame` may not exist when `OnEnable` runs (Blizzard load-on-demand addon not yet loaded), causing `SuppressBlizzardLootFrame()` to silently no-op.
2. **Event gap** - Retail `OnLootOpened` only captured the `autoLoot` flag without suppressing. Suppression was deferred to `OnLootReady`, giving Blizzard's frame a full event cycle to process `LOOT_OPENED` and show itself.
3. **Dispatch race** - `UnregisterAllEvents()` mid-dispatch doesn't retroactively cancel already-queued handlers for the current event.

### Solution

Three new layers on top of the existing event stripping:

| Layer | File | Mechanism |
|-------|------|-----------|
| Hook safety net | `Init.lua` | `hooksecurefunc(LootFrame, "Show", ...)` - catches any `Show()` call, config-gated |
| LoD detection | `Init.lua` | `ADDON_LOADED` watcher suppresses as soon as `LootFrame` appears |
| Early suppression | `LootListener_Retail.lua` | Suppress in `OnLootOpened` (fires before `LOOT_READY`) |

### Changes

- `DragonLoot/Core/Init.lua` - Hook-based suppression, LoD watcher, OnDisable cleanup
- `DragonLoot/Listeners/LootListener_Retail.lua` - Early suppression in OnLootOpened

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues

<!-- No linked issue -->

## Testing

- [x] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [ ] WoW version(s) tested on: Retail

### Test plan

- [ ] Loot a mob on Retail - only DragonLoot's frame should appear
- [ ] `/dl test` works as before
- [ ] `/dl disable` then `/dl enable` - suppression re-applies
- [ ] Disable custom loot window in config + `/reload` - Blizzard frame works normally

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format