### PR TITLE
feat: add more visual options (#63)

### DIFF
--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -37,6 +37,12 @@ local defaults = {
             lock = false,
             timerBarHeight = 12,
             timerBarTexture = "Blizzard",
+            timerBarBorder = false,
+            timerBarBorderColor = { r = 0.3, g = 0.3, b = 0.3 },
+            timerBarColorMode = "gradient",
+            timerBarColor = { r = 0, g = 1, b = 0 },
+            timerBarBackgroundColor = { r = 0.1, g = 0.1, b = 0.1 },
+            timerBarBackgroundAlpha = 0.8,
             frameWidth = 328,
             rowSpacing = 4,
             timerBarSpacing = 4,
@@ -44,6 +50,10 @@ local defaults = {
             buttonSize = 24,
             buttonSpacing = 4,
             frameSpacing = 4,
+            frameMinHeight = 68,
+            compactTextLayout = false,
+            timerBarStyle = "normal",
+            timerBarMinimalHeight = 3,
         },
 
         history = {
@@ -55,12 +65,14 @@ local defaults = {
             minQuality = 2,  -- Uncommon
             entrySpacing = 2,
             contentPadding = 6,
+            showRollDetails = true,
         },
 
         appearance = {
             font = "Friz Quadrata TT",
             fontSize = 12,
             fontOutline = "OUTLINE",
+            fontShadow = true,
             lootIconSize = 36,
             rollIconSize = 36,
             historyIconSize = 24,

--- a/DragonLoot/Display/DisplayUtils.lua
+++ b/DragonLoot/Display/DisplayUtils.lua
@@ -57,6 +57,22 @@ function DisplayUtils.GetFont(db)
 end
 
 -------------------------------------------------------------------------------
+-- ApplyFontShadow(fontString, db) - apply or remove text shadow
+-------------------------------------------------------------------------------
+
+function DisplayUtils.ApplyFontShadow(fontString, db)
+    if not fontString or not fontString.SetShadowOffset then return end
+    local appearance = db and db.profile and db.profile.appearance
+    if not appearance then return end
+    if appearance.fontShadow then
+        fontString:SetShadowOffset(1, -1)
+        fontString:SetShadowColor(0, 0, 0, 1)
+    else
+        fontString:SetShadowOffset(0, 0)
+    end
+end
+
+-------------------------------------------------------------------------------
 -- GetBackdropSettings(db) - returns a backdrop table
 -------------------------------------------------------------------------------
 

--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -17,8 +17,10 @@ local UIParent = UIParent
 local GetTime = GetTime
 local RAID_CLASS_COLORS = RAID_CLASS_COLORS
 local HandleModifiedItemClick = HandleModifiedItemClick
+local IsShiftKeyDown = IsShiftKeyDown
 local math_floor = math.floor
 local string_format = string.format
+local tostring = tostring
 
 local L = ns.L
 local DU = ns.DisplayUtils
@@ -37,6 +39,8 @@ local SCROLLBAR_GAP = 2
 local DEFAULT_HISTORY_X_OFFSET = 200
 local SCROLLBAR_THUMB_HEIGHT = 30
 local TIME_REFRESH_INTERVAL = 10
+local DETAIL_ROW_HEIGHT = 16
+local DETAIL_PADDING = 4
 
 local function GetEntrySpacing()
     return ns.Addon.db.profile.history.entrySpacing or 2
@@ -62,12 +66,17 @@ local scrollBar
 local entryPool = {}
 local entryCount = 0
 local activeEntries = {}
+local expandedEntries = {}
+local detailRowPool = {}
 
 -------------------------------------------------------------------------------
 -- History data (populated by listeners)
 -------------------------------------------------------------------------------
 
 ns.historyData = {}
+
+-- Forward declaration for RefreshHistory (used by OnEntryClick)
+local RefreshHistory
 
 -------------------------------------------------------------------------------
 -- Backdrop and font wrappers (delegate to DisplayUtils)
@@ -212,7 +221,90 @@ local function CreateEntryFrame()
     entry.highlight:SetAllPoints()
     entry.highlight:SetColorTexture(1, 1, 1, 0.05)
 
+    -- Detail container for expanded roll results
+    entry.detailContainer = CreateFrame("Frame", nil, entry)
+    entry.detailContainer:SetPoint("TOPLEFT", entry.icon, "BOTTOMLEFT", 0, -2)
+    entry.detailContainer:SetPoint("RIGHT", entry, "RIGHT", 0, 0)
+    entry.detailContainer:Hide()
+
+    -- Expand indicator
+    entry.expandIndicator = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.expandIndicator:SetPoint("BOTTOMRIGHT", entry.icon, "BOTTOMRIGHT", -1, 1)
+    entry.expandIndicator:SetTextColor(1, 0.82, 0)
+    entry.expandIndicator:Hide()
+
+    entry.detailRows = {}
+
     return entry
+end
+
+-------------------------------------------------------------------------------
+-- Detail row creation and pool management
+-------------------------------------------------------------------------------
+
+local function CreateDetailRow(parent)
+    local row = CreateFrame("Frame", nil, parent)
+    row:SetHeight(DETAIL_ROW_HEIGHT)
+
+    local fontPath, fontSize, fontOutline = GetFont()
+
+    row.playerName = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    row.playerName:SetPoint("LEFT", row, "LEFT", 4, 0)
+    row.playerName:SetFont(fontPath, fontSize - 2, fontOutline)
+    row.playerName:SetJustifyH("LEFT")
+
+    row.rollType = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    row.rollType:SetPoint("CENTER", row, "CENTER", 0, 0)
+    row.rollType:SetFont(fontPath, fontSize - 2, fontOutline)
+    row.rollType:SetJustifyH("CENTER")
+    row.rollType:SetTextColor(0.8, 0.8, 0.8)
+
+    row.rollValue = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    row.rollValue:SetPoint("RIGHT", row, "RIGHT", -4, 0)
+    row.rollValue:SetFont(fontPath, fontSize - 2, fontOutline)
+    row.rollValue:SetJustifyH("RIGHT")
+    row.rollValue:SetTextColor(0.9, 0.9, 0.9)
+
+    return row
+end
+
+local function AcquireDetailRow(parent)
+    local row = table.remove(detailRowPool)
+    if not row then
+        row = CreateDetailRow(parent)
+    else
+        row:SetParent(parent)
+    end
+    row:Show()
+    return row
+end
+
+local function ReleaseDetailRow(row)
+    row:Hide()
+    row:ClearAllPoints()
+    row.playerName:SetText("")
+    row.rollType:SetText("")
+    row.rollValue:SetText("")
+    table.insert(detailRowPool, row)
+end
+
+local function ReleaseEntryDetails(entry)
+    if entry.detailRows then
+        for i = #entry.detailRows, 1, -1 do
+            ReleaseDetailRow(entry.detailRows[i])
+            entry.detailRows[i] = nil
+        end
+    end
+    if entry.detailContainer then
+        entry.detailContainer:Hide()
+    end
+end
+
+local function GetEntryKey(data)
+    if data.dropKey then
+        return data.dropKey
+    end
+    return (data.timestamp or 0) .. "|" .. (data.itemLink or "") .. "|" .. (data.winner or "")
 end
 
 -------------------------------------------------------------------------------
@@ -231,15 +323,19 @@ end
 local function ReleaseEntry(entry)
     if entry._isPooled then return end
     entry._isPooled = true
+    ReleaseEntryDetails(entry)
     entry:Hide()
     entry:ClearAllPoints()
     entry.itemLink = nil
     entry.quality = nil
+    entry._entryKey = nil
+    entry._rollResults = nil
     entry.icon:SetTexture(nil)
     entry.itemName:SetText("")
     entry.winnerName:SetText("")
     entry.rollInfo:SetText("")
     entry.timeText:SetText("")
+    if entry.expandIndicator then entry.expandIndicator:Hide() end
     entry:SetScript("OnClick", nil)
     entry:SetScript("OnEnter", nil)
     entry:SetScript("OnLeave", nil)
@@ -269,10 +365,81 @@ local function OnEntryLeave()
     GameTooltip:Hide()
 end
 
-local function OnEntryClick(self)
-    if self.itemLink then
+local function OnEntryClick(self, _button)
+    if not self.itemLink then return end
+
+    local db = ns.Addon.db.profile
+    local canExpand = db.history.showRollDetails and self._rollResults
+        and #self._rollResults > 0
+
+    -- Shift-click always inserts item link
+    if IsShiftKeyDown() then
         HandleModifiedItemClick(self.itemLink)
+        return
     end
+
+    -- Toggle expand/collapse if roll details are available
+    if canExpand then
+        local key = self._entryKey
+        if expandedEntries[key] then
+            expandedEntries[key] = nil
+        else
+            expandedEntries[key] = true
+        end
+        RefreshHistory()
+        return
+    end
+
+    -- Default: insert item link
+    HandleModifiedItemClick(self.itemLink)
+end
+
+-------------------------------------------------------------------------------
+-- Populate detail rows for an expanded entry
+-------------------------------------------------------------------------------
+
+local function PopulateEntryDetails(entry, rollResults)
+    ReleaseEntryDetails(entry)
+
+    if not rollResults or #rollResults == 0 then
+        entry.detailContainer:Hide()
+        return
+    end
+
+    local fontPath, fontSize, fontOutline = GetFont()
+    entry.detailRows = {}
+
+    for idx, result in ipairs(rollResults) do
+        local row = AcquireDetailRow(entry.detailContainer)
+        row:SetPoint("TOPLEFT", entry.detailContainer, "TOPLEFT", 0,
+            -((idx - 1) * DETAIL_ROW_HEIGHT))
+        row:SetPoint("RIGHT", entry.detailContainer, "RIGHT", 0, 0)
+
+        -- Font
+        row.playerName:SetFont(fontPath, fontSize - 2, fontOutline)
+        DU.ApplyFontShadow(row.playerName, ns.Addon.db)
+        row.rollType:SetFont(fontPath, fontSize - 2, fontOutline)
+        DU.ApplyFontShadow(row.rollType, ns.Addon.db)
+        row.rollValue:SetFont(fontPath, fontSize - 2, fontOutline)
+        DU.ApplyFontShadow(row.rollValue, ns.Addon.db)
+
+        -- Player name (class colored)
+        local cr, cg, cb = GetClassColor(result.playerClass)
+        row.playerName:SetText(result.playerName or "")
+        row.playerName:SetTextColor(cr, cg, cb)
+
+        -- Roll type
+        row.rollType:SetText(GetRollTypeText(result.rollType))
+
+        -- Roll value
+        row.rollValue:SetText(result.roll and tostring(result.roll) or "-")
+
+        entry.detailRows[idx] = row
+    end
+
+    local containerHeight = #rollResults * DETAIL_ROW_HEIGHT + DETAIL_PADDING
+    entry.detailContainer:SetHeight(containerHeight)
+    entry.detailContainer:Show()
 end
 
 -------------------------------------------------------------------------------
@@ -299,6 +466,7 @@ local function PopulateEntry(entry, data)
     -- Item name (quality colored)
     local fontPath, fontSize, fontOutline = GetFont()
     entry.itemName:SetFont(fontPath, fontSize - 1, fontOutline)
+    DU.ApplyFontShadow(entry.itemName, ns.Addon.db)
     if data.itemLink then
         -- Extract name from link for display, fallback to link itself
         local name = data.itemLink:match("%[(.-)%]") or data.itemLink
@@ -310,6 +478,7 @@ local function PopulateEntry(entry, data)
 
     -- Winner name (class colored)
     entry.winnerName:SetFont(fontPath, fontSize - 2, fontOutline)
+    DU.ApplyFontShadow(entry.winnerName, ns.Addon.db)
     if data.winner then
         local cr, cg, cb = GetClassColor(data.winnerClass)
         entry.winnerName:SetText(data.winner)
@@ -320,6 +489,7 @@ local function PopulateEntry(entry, data)
 
     -- Roll info
     entry.rollInfo:SetFont(fontPath, fontSize - 2, fontOutline)
+    DU.ApplyFontShadow(entry.rollInfo, ns.Addon.db)
     if data.isDirectLoot then
         entry.rollInfo:SetText(L["Looted"])
         entry.rollInfo:SetTextColor(0.6, 0.6, 0.6)
@@ -334,7 +504,32 @@ local function PopulateEntry(entry, data)
 
     -- Time
     entry.timeText:SetFont(fontPath, fontSize - 2, fontOutline)
+    DU.ApplyFontShadow(entry.timeText, ns.Addon.db)
     entry.timeText:SetText(FormatTimeAgo(data.timestamp))
+
+    -- Roll details expand/collapse
+    local db = ns.Addon.db.profile
+    local entryKey = GetEntryKey(data)
+    entry._entryKey = entryKey
+    entry._rollResults = data.rollResults
+
+    if db.history.showRollDetails and data.rollResults and #data.rollResults > 0 then
+        local fontPath2, fontSize2, fontOutline2 = GetFont()
+        entry.expandIndicator:SetFont(fontPath2, fontSize2 - 3, fontOutline2)
+        DU.ApplyFontShadow(entry.expandIndicator, ns.Addon.db)
+        if expandedEntries[entryKey] then
+            entry.expandIndicator:SetText("-")
+            entry.expandIndicator:Show()
+            PopulateEntryDetails(entry, data.rollResults)
+        else
+            entry.expandIndicator:SetText("+")
+            entry.expandIndicator:Show()
+            ReleaseEntryDetails(entry)
+        end
+    else
+        entry.expandIndicator:Hide()
+        ReleaseEntryDetails(entry)
+    end
 
     -- Interaction scripts (named functions, no per-entry closures)
     entry:SetScript("OnEnter", OnEntryEnter)
@@ -367,11 +562,12 @@ end
 -- Refresh history display
 -------------------------------------------------------------------------------
 
-local function RefreshHistory()
+RefreshHistory = function()
     if not containerFrame or not containerFrame:IsShown() then return end
 
     ReleaseAllEntries()
 
+    local db = ns.Addon.db.profile
     local entryHeight = GetEntryHeight()
     local entrySpacing = GetEntrySpacing()
     local yOffset = 0
@@ -382,11 +578,21 @@ local function RefreshHistory()
         entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", 0, -yOffset)
         entry:SetPoint("RIGHT", scrollChild, "RIGHT", 0, 0)
         activeEntries[i] = entry
-        yOffset = yOffset + entryHeight + entrySpacing
+
+        -- Variable height: base + expanded detail rows
+        local thisHeight = entryHeight
+        local entryKey = GetEntryKey(data)
+        if db.history.showRollDetails and expandedEntries[entryKey]
+            and data.rollResults and #data.rollResults > 0 then
+            thisHeight = entryHeight + (#data.rollResults * DETAIL_ROW_HEIGHT)
+                + DETAIL_PADDING
+        end
+        entry:SetHeight(thisHeight)
+        yOffset = yOffset + thisHeight + entrySpacing
     end
 
-    -- Resize scroll child to fit all entries
-    local totalHeight = #ns.historyData * (entryHeight + entrySpacing)
+    -- Resize scroll child to fit all entries (use accumulated yOffset)
+    local totalHeight = yOffset
     if totalHeight < 1 then totalHeight = 1 end
     scrollChild:SetHeight(totalHeight)
 
@@ -437,6 +643,7 @@ local function CreateTitleBar(parent)
     titleBar.text = titleBar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     titleBar.text:SetPoint("LEFT", titleBar, "LEFT", 8, 0)
     titleBar.text:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(titleBar.text, ns.Addon.db)
     titleBar.text:SetText(L["DragonLoot - Loot History"])
     titleBar.text:SetTextColor(1, 0.82, 0)
 
@@ -664,6 +871,7 @@ function ns.HistoryFrame.ApplySettings()
     -- Update title font
     local fontPath, fontSize, fontOutline = GetFont()
     containerFrame.titleBar.text:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(containerFrame.titleBar.text, ns.Addon.db)
 
     -- Update visible entries with current icon size and entry height
     local db = ns.Addon.db.profile
@@ -674,9 +882,25 @@ function ns.HistoryFrame.ApplySettings()
             entry:SetHeight(entryHeight)
             entry.icon:SetSize(iconSize, iconSize)
             entry.itemName:SetFont(fontPath, fontSize - 1, fontOutline)
+            DU.ApplyFontShadow(entry.itemName, ns.Addon.db)
             entry.winnerName:SetFont(fontPath, fontSize - 2, fontOutline)
+            DU.ApplyFontShadow(entry.winnerName, ns.Addon.db)
             entry.rollInfo:SetFont(fontPath, fontSize - 2, fontOutline)
+            DU.ApplyFontShadow(entry.rollInfo, ns.Addon.db)
             entry.timeText:SetFont(fontPath, fontSize - 2, fontOutline)
+            DU.ApplyFontShadow(entry.timeText, ns.Addon.db)
+
+            -- Update detail rows if expanded
+            if entry.detailRows then
+                for _, row in ipairs(entry.detailRows) do
+                    row.playerName:SetFont(fontPath, fontSize - 2, fontOutline)
+                    DU.ApplyFontShadow(row.playerName, ns.Addon.db)
+                    row.rollType:SetFont(fontPath, fontSize - 2, fontOutline)
+                    DU.ApplyFontShadow(row.rollType, ns.Addon.db)
+                    row.rollValue:SetFont(fontPath, fontSize - 2, fontOutline)
+                    DU.ApplyFontShadow(row.rollValue, ns.Addon.db)
+                end
+            end
 
             -- Refresh quality border visibility
             if entry.itemLink and db.appearance.qualityBorder then
@@ -747,6 +971,7 @@ function ns.HistoryFrame.SetEntries(entries)
 end
 
 function ns.HistoryFrame.ClearHistory()
+    wipe(expandedEntries)
     wipe(ns.historyData)
     if containerFrame and containerFrame:IsShown() then
         RefreshHistory()

--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -560,6 +560,7 @@ local function RenderSlot(slot, data, isTest)
 
     -- Item name
     slot.itemName:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(slot.itemName, ns.Addon.db)
     slot.itemName:SetText(data.name)
     slot.itemName:SetTextColor(r, g, b)
 
@@ -575,6 +576,7 @@ local function RenderSlot(slot, data, isTest)
     if data.subText then
         local subFontSize = math.max(fontSize - 2, 8)
         slot.subText:SetFont(fontPath, subFontSize, fontOutline)
+        DU.ApplyFontShadow(slot.subText, ns.Addon.db)
         slot.subText:SetText(data.subText)
         slot.subText:SetTextColor(0.6, 0.6, 0.6)
         slot.subText:Show()
@@ -694,6 +696,7 @@ local function CreateContainerFrame()
     frame.title = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     frame.title:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -6)
     frame.title:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(frame.title, ns.Addon.db)
     frame.title:SetText(L["Loot"])
     frame.title:SetTextColor(1, 0.82, 0)
 
@@ -972,11 +975,13 @@ function ns.LootFrame.ApplySettings()
     -- Update title font
     local fontPath, fontSize, fontOutline = GetFont()
     containerFrame.title:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(containerFrame.title, ns.Addon.db)
 
     -- Update visible slots
     for _, slot in ipairs(activeSlots) do
         if slot:IsShown() then
             slot.itemName:SetFont(fontPath, fontSize, fontOutline)
+            DU.ApplyFontShadow(slot.itemName, ns.Addon.db)
             -- Refresh quality border visibility
             if slot.slotIndex then
                 local _, _, _, quality = GetNormalizedSlotInfo(slot.slotIndex)
@@ -992,6 +997,7 @@ function ns.LootFrame.ApplySettings()
                 -- Update sub-text font
                 local subFontSize = math.max(fontSize - 2, 8)
                 slot.subText:SetFont(fontPath, subFontSize, fontOutline)
+                DU.ApplyFontShadow(slot.subText, ns.Addon.db)
                 -- Refresh row background and highlight
                 ApplySlotBackground(slot, quality)
                 slot.highlight:SetColorTexture(slot._qr or 1, slot._qg or 1, slot._qb or 1, 0.15)

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -177,6 +177,66 @@ local function GetTimerBarMinimalHeight()
     return ns.Addon.db.profile.rollFrame.timerBarMinimalHeight or 3
 end
 
+local function ApplyTextLayoutOffsets(frame, db, compact, iconSize, padding, borderSize, rowSpacing)
+    -- Item name top-left anchor (shared by both modes)
+    frame.itemName:ClearAllPoints()
+    frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT",
+        iconSize + padding + 6 + borderSize, -(padding + borderSize))
+
+    if compact then
+        -- Compact: buttons sit on the same row as the item name
+        frame.passButton:ClearAllPoints()
+        frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
+        frame.passButton:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+
+        -- Determine leftmost button
+        local leftmostButton = frame.needButton
+        if frame.transmogButton and frame.transmogButton:IsShown() then
+            leftmostButton = frame.transmogButton
+        end
+
+        -- bindText sits to the left of the buttons
+        frame.bindText:ClearAllPoints()
+        frame.bindText:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
+        frame.bindText:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+
+        -- itemName fills remaining space, stopping before bindText
+        frame.itemName:SetPoint("RIGHT", frame.bindText, "LEFT", -2, 0)
+    else
+        -- Normal: stacked rows
+        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
+
+        frame.bindText:ClearAllPoints()
+        frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -rowSpacing)
+
+        frame.passButton:ClearAllPoints()
+        frame.passButton:SetPoint("TOPRIGHT", frame.itemName, "BOTTOMRIGHT", 0, -rowSpacing)
+    end
+end
+
+local function ApplyTimerBarOffsets(frame, db, iconSize, padding, borderSize, timerBarSpacing)
+    local timerBarAnchor = frame.timerBar.container or frame.timerBar
+    timerBarAnchor:ClearAllPoints()
+
+    if GetTimerBarStyle() == "minimal" then
+        -- Minimal: full width at very bottom, thin bar, no text
+        local minimalHeight = GetTimerBarMinimalHeight()
+        timerBarAnchor:SetHeight(minimalHeight)
+        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", borderSize, borderSize)
+        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -borderSize, borderSize)
+        frame.timerBar.text:Hide()
+    else
+        -- Normal: indented past icon, configurable height, text visible
+        local barHeight = db.rollFrame.timerBarHeight or 12
+        timerBarAnchor:SetHeight(barHeight)
+        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",
+            iconSize + padding + 6 + borderSize, timerBarSpacing + borderSize)
+        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
+            -(padding + 2 + borderSize), timerBarSpacing + borderSize)
+        frame.timerBar.text:Show()
+    end
+end
+
 local function ApplyLayoutOffsets(frame)
     local db = ns.Addon.db.profile
     local borderSize = db.appearance.borderSize or 1
@@ -190,57 +250,8 @@ local function ApplyLayoutOffsets(frame)
     frame.iconFrame:ClearAllPoints()
     frame.iconFrame:SetPoint("LEFT", frame, "LEFT", padding + borderSize, 0)
 
-    -- Item name
-    frame.itemName:ClearAllPoints()
-    frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT",
-        iconSize + padding + 6 + borderSize, -(padding + borderSize))
-
-    if compact then
-        -- Compact: position buttons first, then anchor item name to leftmost button
-        frame.passButton:ClearAllPoints()
-        frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
-        frame.passButton:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
-
-        local leftmostButton = frame.needButton
-        if frame.transmogButton and frame.transmogButton:IsShown() then
-            leftmostButton = frame.transmogButton
-        end
-        frame.itemName:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
-
-        frame.bindText:ClearAllPoints()
-        frame.bindText:SetPoint("LEFT", frame.itemName, "RIGHT", 4, 0)
-    else
-        -- Normal: stacked rows
-        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
-
-        frame.bindText:ClearAllPoints()
-        frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -rowSpacing)
-
-        frame.passButton:ClearAllPoints()
-        frame.passButton:SetPoint("TOPRIGHT", frame.itemName, "BOTTOMRIGHT", 0, -rowSpacing)
-    end
-
-    -- Timer bar container - style-dependent positioning
-    local timerBarAnchor = frame.timerBar.container or frame.timerBar
-    timerBarAnchor:ClearAllPoints()
-
-    if GetTimerBarStyle() == "minimal" then
-        -- Minimal: full width at very bottom, thin bar, no text
-        local minimalHeight = GetTimerBarMinimalHeight()
-        timerBarAnchor:SetHeight(minimalHeight)
-        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", borderSize, borderSize)
-        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -borderSize, borderSize)
-        frame.timerBar.text:Hide()
-    else
-        -- Normal: indented past icon, configurable height, text visible
-        local barHeight = ns.Addon.db.profile.rollFrame.timerBarHeight or 12
-        timerBarAnchor:SetHeight(barHeight)
-        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",
-            iconSize + padding + 6 + borderSize, timerBarSpacing + borderSize)
-        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-            -(padding + 2 + borderSize), timerBarSpacing + borderSize)
-        frame.timerBar.text:Show()
-    end
+    ApplyTextLayoutOffsets(frame, db, compact, iconSize, padding, borderSize, rowSpacing)
+    ApplyTimerBarOffsets(frame, db, iconSize, padding, borderSize, timerBarSpacing)
 end
 
 -------------------------------------------------------------------------------
@@ -655,7 +666,8 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     -- Timer bar starts full
     frame.timerBar:SetMinMaxValues(0, 1)
     frame.timerBar:SetValue(1)
-    frame.timerBar:SetStatusBarColor(0, 1, 0)
+    local ir, ig, ib = GetTimerBarColor(1, 1)
+    frame.timerBar:SetStatusBarColor(ir, ig, ib)
     if isTest and data.duration then
         frame.timerBar.text:SetText(string.format("%.0f", data.duration))
     else

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -177,7 +177,7 @@ local function GetTimerBarMinimalHeight()
     return ns.Addon.db.profile.rollFrame.timerBarMinimalHeight or 3
 end
 
-local function ApplyTextLayoutOffsets(frame, db, compact, iconSize, padding, borderSize, rowSpacing)
+local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderSize, rowSpacing)
     -- Item name top-left anchor (shared by both modes)
     frame.itemName:ClearAllPoints()
     frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT",
@@ -250,7 +250,7 @@ local function ApplyLayoutOffsets(frame)
     frame.iconFrame:ClearAllPoints()
     frame.iconFrame:SetPoint("LEFT", frame, "LEFT", padding + borderSize, 0)
 
-    ApplyTextLayoutOffsets(frame, db, compact, iconSize, padding, borderSize, rowSpacing)
+    ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderSize, rowSpacing)
     ApplyTimerBarOffsets(frame, db, iconSize, padding, borderSize, timerBarSpacing)
 end
 

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -43,6 +43,17 @@ local function ApplyTimerBarBorder(container)
     end
 end
 
+local function ApplyTimerBarInset(bar, container)
+    local hasBorder = ns.Addon.db.profile.rollFrame.timerBarBorder
+    bar:ClearAllPoints()
+    if hasBorder then
+        bar:SetPoint("TOPLEFT", container, "TOPLEFT", 1, -1)
+        bar:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -1, 1)
+    else
+        bar:SetAllPoints(container)
+    end
+end
+
 -------------------------------------------------------------------------------
 -- Roll type constants (values used by RollOnLoot)
 -------------------------------------------------------------------------------
@@ -185,15 +196,19 @@ local function ApplyLayoutOffsets(frame)
         iconSize + padding + 6 + borderSize, -(padding + borderSize))
 
     if compact then
-        -- Compact: item name + bind text + pass button on one line
-        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize + 80), 0)
-
-        frame.bindText:ClearAllPoints()
-        frame.bindText:SetPoint("LEFT", frame.itemName, "RIGHT", 4, 0)
-
+        -- Compact: position buttons first, then anchor item name to leftmost button
         frame.passButton:ClearAllPoints()
         frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
         frame.passButton:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+
+        local leftmostButton = frame.needButton
+        if frame.transmogButton and frame.transmogButton:IsShown() then
+            leftmostButton = frame.transmogButton
+        end
+        frame.itemName:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
+
+        frame.bindText:ClearAllPoints()
+        frame.bindText:SetPoint("LEFT", frame.itemName, "RIGHT", 4, 0)
     else
         -- Normal: stacked rows
         frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
@@ -431,10 +446,9 @@ local function CreateTimerBar(parent)
     container:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", iconSize + padding + 6, timerBarSpacing)
     container:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -(padding + 2), timerBarSpacing)
 
-    -- StatusBar fills the container with 1px inset for the border
+    -- StatusBar fills the container (inset when border is enabled)
     local bar = CreateFrame("StatusBar", nil, container)
-    bar:SetPoint("TOPLEFT", container, "TOPLEFT", 1, -1)
-    bar:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -1, 1)
+    ApplyTimerBarInset(bar, container)
     bar:SetStatusBarTexture(barTexture)
     bar:SetMinMaxValues(0, 1)
     bar:SetValue(1)
@@ -625,6 +639,8 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     -- Item name
     frame.itemName:SetFont(fontPath, fontSize, fontOutline)
     DU.ApplyFontShadow(frame.itemName, ns.Addon.db)
+    DU.ApplyFontShadow(frame.bindText, ns.Addon.db)
+    DU.ApplyFontShadow(frame.timerBar.text, ns.Addon.db)
     frame.itemName:SetText(data.name)
     frame.itemName:SetTextColor(r, g, b)
 
@@ -942,6 +958,7 @@ function ns.RollFrame.ApplySettings()
                     frame.timerBar.container:SetHeight(barHeight)
                 end
                 ApplyTimerBarBorder(frame.timerBar.container)
+                ApplyTimerBarInset(frame.timerBar, frame.timerBar.container)
             end
 
             -- Update timer bar background color

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -25,6 +25,25 @@ local L = ns.L
 local DU = ns.DisplayUtils
 
 -------------------------------------------------------------------------------
+-- Timer bar border helper
+-------------------------------------------------------------------------------
+
+local function ApplyTimerBarBorder(container)
+    local db = ns.Addon.db.profile
+    local rollCfg = db.rollFrame
+    if rollCfg.timerBarBorder then
+        container:SetBackdrop({
+            edgeFile = DU.WHITE8x8,
+            edgeSize = 1,
+        })
+        local c = rollCfg.timerBarBorderColor or { r = 0.3, g = 0.3, b = 0.3 }
+        container:SetBackdropBorderColor(c.r, c.g, c.b, 0.8)
+    else
+        container:SetBackdrop(nil)
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Roll type constants (values used by RollOnLoot)
 -------------------------------------------------------------------------------
 
@@ -78,7 +97,6 @@ local PASS_ICON = "Interface\\Buttons\\UI-GroupLoot-Pass-Up"
 -- Frame dimensions
 -------------------------------------------------------------------------------
 
-local FRAME_BASE_HEIGHT = 68
 local MAX_VISIBLE_ROLLS = 4
 local DEFAULT_ROLL_ANCHOR_Y = -200
 local ROLL_FRAME_EXTRA_HEIGHT = 18
@@ -136,6 +154,18 @@ local function GetTimerBarSpacing()
     return ns.Addon.db.profile.rollFrame.timerBarSpacing or 4
 end
 
+local function GetFrameMinHeight()
+    return ns.Addon.db.profile.rollFrame.frameMinHeight or 68
+end
+
+local function GetTimerBarStyle()
+    return ns.Addon.db.profile.rollFrame.timerBarStyle or "normal"
+end
+
+local function GetTimerBarMinimalHeight()
+    return ns.Addon.db.profile.rollFrame.timerBarMinimalHeight or 3
+end
+
 local function ApplyLayoutOffsets(frame)
     local db = ns.Addon.db.profile
     local borderSize = db.appearance.borderSize or 1
@@ -143,31 +173,59 @@ local function ApplyLayoutOffsets(frame)
     local padding = GetContentPadding()
     local rowSpacing = GetRowSpacing()
     local timerBarSpacing = GetTimerBarSpacing()
+    local compact = db.rollFrame.compactTextLayout
 
     -- Icon position (vertically centered on left)
     frame.iconFrame:ClearAllPoints()
     frame.iconFrame:SetPoint("LEFT", frame, "LEFT", padding + borderSize, 0)
 
-    -- Item name - anchored to frame top (independent of icon vertical centering)
+    -- Item name
     frame.itemName:ClearAllPoints()
     frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT",
         iconSize + padding + 6 + borderSize, -(padding + borderSize))
-    frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
 
-    -- BoP indicator - Row 2 left side, below item name with rowSpacing gap
-    frame.bindText:ClearAllPoints()
-    frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -rowSpacing)
+    if compact then
+        -- Compact: item name + bind text + pass button on one line
+        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize + 80), 0)
 
-    -- Timer bar - Row 3 at bottom with timerBarSpacing
-    frame.timerBar:ClearAllPoints()
-    frame.timerBar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",
-        iconSize + padding + 6 + borderSize, timerBarSpacing + borderSize)
-    frame.timerBar:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-        -(padding + 2 + borderSize), timerBarSpacing + borderSize)
+        frame.bindText:ClearAllPoints()
+        frame.bindText:SetPoint("LEFT", frame.itemName, "RIGHT", 4, 0)
 
-    -- Pass button - Row 2 right side, below item name with rowSpacing gap
-    frame.passButton:ClearAllPoints()
-    frame.passButton:SetPoint("TOPRIGHT", frame.itemName, "BOTTOMRIGHT", 0, -rowSpacing)
+        frame.passButton:ClearAllPoints()
+        frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
+        frame.passButton:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+    else
+        -- Normal: stacked rows
+        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
+
+        frame.bindText:ClearAllPoints()
+        frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -rowSpacing)
+
+        frame.passButton:ClearAllPoints()
+        frame.passButton:SetPoint("TOPRIGHT", frame.itemName, "BOTTOMRIGHT", 0, -rowSpacing)
+    end
+
+    -- Timer bar container - style-dependent positioning
+    local timerBarAnchor = frame.timerBar.container or frame.timerBar
+    timerBarAnchor:ClearAllPoints()
+
+    if GetTimerBarStyle() == "minimal" then
+        -- Minimal: full width at very bottom, thin bar, no text
+        local minimalHeight = GetTimerBarMinimalHeight()
+        timerBarAnchor:SetHeight(minimalHeight)
+        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", borderSize, borderSize)
+        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -borderSize, borderSize)
+        frame.timerBar.text:Hide()
+    else
+        -- Normal: indented past icon, configurable height, text visible
+        local barHeight = ns.Addon.db.profile.rollFrame.timerBarHeight or 12
+        timerBarAnchor:SetHeight(barHeight)
+        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",
+            iconSize + padding + 6 + borderSize, timerBarSpacing + borderSize)
+        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
+            -(padding + 2 + borderSize), timerBarSpacing + borderSize)
+        frame.timerBar.text:Show()
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -175,15 +233,20 @@ end
 -------------------------------------------------------------------------------
 
 local function GetTimerBarColor(timeLeft, rollTime)
+    local db = ns.Addon.db.profile.rollFrame
+    if db.timerBarColorMode == "custom" then
+        local c = db.timerBarColor
+        return c.r, c.g, c.b
+    end
+
+    -- Gradient: green -> yellow -> red
     if rollTime <= 0 then return 1, 0, 0 end
     local ratio = timeLeft / rollTime
 
     if ratio > 0.5 then
-        -- Green to Yellow
         local t = (ratio - 0.5) / 0.5
         return 1 - t, 1, 0
     else
-        -- Yellow to Red
         local t = ratio / 0.5
         return 1, t, 0
     end
@@ -358,13 +421,20 @@ local function CreateTimerBar(parent)
     local barTexture = LSM:Fetch("statusbar", db.rollFrame.timerBarTexture)
         or "Interface\\TargetingFrame\\UI-StatusBar"
 
-    local bar = CreateFrame("StatusBar", nil, parent)
-    bar:SetHeight(barHeight)
     local iconSize = GetRollIconSize()
     local padding = GetContentPadding()
     local timerBarSpacing = GetTimerBarSpacing()
-    bar:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", iconSize + padding + 6, timerBarSpacing)
-    bar:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -(padding + 2), timerBarSpacing)
+
+    -- Container frame owns the optional border
+    local container = CreateFrame("Frame", nil, parent, "BackdropTemplate")
+    container:SetHeight(barHeight)
+    container:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", iconSize + padding + 6, timerBarSpacing)
+    container:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -(padding + 2), timerBarSpacing)
+
+    -- StatusBar fills the container with 1px inset for the border
+    local bar = CreateFrame("StatusBar", nil, container)
+    bar:SetPoint("TOPLEFT", container, "TOPLEFT", 1, -1)
+    bar:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -1, 1)
     bar:SetStatusBarTexture(barTexture)
     bar:SetMinMaxValues(0, 1)
     bar:SetValue(1)
@@ -372,11 +442,15 @@ local function CreateTimerBar(parent)
 
     bar.bg = bar:CreateTexture(nil, "BACKGROUND")
     bar.bg:SetAllPoints()
-    bar.bg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
+    local bgColor = db.rollFrame.timerBarBackgroundColor
+    bar.bg:SetColorTexture(bgColor.r, bgColor.g, bgColor.b, db.rollFrame.timerBarBackgroundAlpha)
 
     bar.text = bar:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     bar.text:SetPoint("CENTER", bar, "CENTER", 0, 0)
     bar.text:SetTextColor(1, 1, 1)
+
+    bar.container = container
+    ApplyTimerBarBorder(container)
 
     return bar
 end
@@ -390,7 +464,7 @@ local function CreateRollFrame(index)
     local frameName = "DragonLootRoll" .. rollFrameCount
 
     local frame = CreateFrame("Frame", frameName, anchorFrame, "BackdropTemplate")
-    frame:SetSize(GetFrameWidth(), FRAME_BASE_HEIGHT)
+    frame:SetSize(GetFrameWidth(), GetFrameMinHeight())
     ApplyBackdrop(frame)
     frame:SetFrameStrata("HIGH")
     frame:SetFrameLevel(110)
@@ -535,7 +609,7 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     frame.iconFrame:SetSize(iconSize, iconSize)
 
     -- Adjust frame height based on icon size
-    frame:SetHeight(math.max(FRAME_BASE_HEIGHT, iconSize + ROLL_FRAME_EXTRA_HEIGHT))
+    frame:SetHeight(math.max(GetFrameMinHeight(), iconSize + ROLL_FRAME_EXTRA_HEIGHT))
 
     -- Icon
     frame.iconFrame.icon:SetTexture(data.texture)
@@ -550,6 +624,7 @@ local function RenderRollFrame(frame, data, rollID, isTest)
 
     -- Item name
     frame.itemName:SetFont(fontPath, fontSize, fontOutline)
+    DU.ApplyFontShadow(frame.itemName, ns.Addon.db)
     frame.itemName:SetText(data.name)
     frame.itemName:SetTextColor(r, g, b)
 
@@ -726,7 +801,9 @@ local function StartTestTimer(frameIndex, duration)
         frame.timerBar:SetValue(pct)
         local r, g, b = GetTimerBarColor(remaining, total)
         frame.timerBar:SetStatusBarColor(r, g, b)
-        frame.timerBar.text:SetText(string.format("%.0f", remaining))
+        if GetTimerBarStyle() ~= "minimal" then
+            frame.timerBar.text:SetText(string.format("%.0f", remaining))
+        end
     end)
 end
 
@@ -803,7 +880,10 @@ function ns.RollFrame.UpdateTimer(frameIndex, timeLeft, rollTime)
 
     local r, g, b = GetTimerBarColor(timeLeft, rollTime)
     bar:SetStatusBarColor(r, g, b)
-    bar.text:SetText(string.format("%.0f", timeLeft))
+
+    if GetTimerBarStyle() ~= "minimal" then
+        bar.text:SetText(string.format("%.0f", timeLeft))
+    end
 end
 
 function ns.RollFrame.ApplySettings()
@@ -846,17 +926,34 @@ function ns.RollFrame.ApplySettings()
             end
 
             -- Adjust frame height based on icon size
-            frame:SetHeight(math.max(FRAME_BASE_HEIGHT, iconSize + ROLL_FRAME_EXTRA_HEIGHT))
+            frame:SetHeight(math.max(GetFrameMinHeight(), iconSize + ROLL_FRAME_EXTRA_HEIGHT))
 
             -- Update layout offsets for border thickness
             ApplyLayoutOffsets(frame)
 
             -- Update timer bar
-            frame.timerBar:SetHeight(barHeight)
             frame.timerBar:SetStatusBarTexture(barTexture)
+
+            -- Update timer bar container size and border
+            if frame.timerBar.container then
+                if GetTimerBarStyle() == "minimal" then
+                    frame.timerBar.container:SetHeight(GetTimerBarMinimalHeight())
+                else
+                    frame.timerBar.container:SetHeight(barHeight)
+                end
+                ApplyTimerBarBorder(frame.timerBar.container)
+            end
+
+            -- Update timer bar background color
+            local bgColor = db.rollFrame.timerBarBackgroundColor
+            frame.timerBar.bg:SetColorTexture(bgColor.r, bgColor.g, bgColor.b,
+                db.rollFrame.timerBarBackgroundAlpha)
 
             -- Update fonts
             frame.itemName:SetFont(fontPath, fontSize, fontOutline)
+            DU.ApplyFontShadow(frame.itemName, ns.Addon.db)
+            DU.ApplyFontShadow(frame.bindText, ns.Addon.db)
+            DU.ApplyFontShadow(frame.timerBar.text, ns.Addon.db)
 
             -- Update quality border
             if frame.rollID and frame:IsShown() then

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -195,13 +195,18 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
             leftmostButton = frame.transmogButton
         end
 
-        -- bindText sits to the left of the buttons
-        frame.bindText:ClearAllPoints()
-        frame.bindText:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
-        frame.bindText:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+        if frame.bindText:IsShown() then
+            -- bindText sits to the left of the buttons
+            frame.bindText:ClearAllPoints()
+            frame.bindText:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
+            frame.bindText:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
 
-        -- itemName fills remaining space, stopping before bindText
-        frame.itemName:SetPoint("RIGHT", frame.bindText, "LEFT", -2, 0)
+            -- itemName fills remaining space, stopping before bindText
+            frame.itemName:SetPoint("RIGHT", frame.bindText, "LEFT", -2, 0)
+        else
+            -- No BoP text; itemName extends directly to the leftmost button
+            frame.itemName:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
+        end
     else
         -- Normal: stacked rows
         frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)

--- a/DragonLoot/Listeners/HistoryListener_Classic.lua
+++ b/DragonLoot/Listeners/HistoryListener_Classic.lua
@@ -58,6 +58,24 @@ local function RefreshFromAPI()
             winner, winnerClass, rollType, roll = C_LootHistory.GetPlayerInfo(i, winnerIdx)
         end
 
+        -- Build per-player roll results for history detail expansion
+        local rollResults
+        if numPlayers and numPlayers > 0 then
+            rollResults = {}
+            for pi = 1, numPlayers do
+                local pName, pClass, pRollType, pRoll = C_LootHistory.GetPlayerInfo(i, pi)
+                if pName then
+                    rollResults[#rollResults + 1] = {
+                        playerName = pName,
+                        playerClass = pClass,
+                        rollType = pRollType,
+                        roll = pRoll,
+                    }
+                end
+            end
+            if #rollResults == 0 then rollResults = nil end
+        end
+
         local quality = 1
         if itemLink then
             local _, _, q = GetItemInfo(itemLink)
@@ -74,6 +92,7 @@ local function RefreshFromAPI()
             roll = roll,
             timestamp = now,
             isComplete = isDone,
+            rollResults = rollResults,
         }
     end
 

--- a/DragonLoot/Listeners/HistoryListener_Retail.lua
+++ b/DragonLoot/Listeners/HistoryListener_Retail.lua
@@ -114,6 +114,23 @@ local function ProcessDrop(encounterID, drop)
     local winner = drop.winner
     local leader = drop.currentLeader
 
+    -- Build per-player roll results for history detail expansion
+    local rollResults
+    if drop.rollInfos then
+        rollResults = {}
+        for _, rollInfo in ipairs(drop.rollInfos) do
+            if rollInfo.playerName then
+                rollResults[#rollResults + 1] = {
+                    playerName = rollInfo.playerName,
+                    playerClass = rollInfo.playerClass,
+                    rollType = ConvertRollState(rollInfo.state),
+                    roll = rollInfo.roll,
+                }
+            end
+        end
+        if #rollResults == 0 then rollResults = nil end
+    end
+
     local entry = {
         itemLink = itemLink,
         itemTexture = GetItemTexture(itemLink),
@@ -126,6 +143,7 @@ local function ProcessDrop(encounterID, drop)
         isComplete = drop.allPassed or (winner ~= nil),
         encounterID = encounterID,
         dropKey = dropKey,
+        rollResults = rollResults,
     }
 
     if processedDrops[dropKey] then

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -144,10 +144,13 @@ L["Width"] = true
 -- DragonLoot_Options/Tabs/LootRollTab.lua
 L["Button Size"] = true
 L["Button Spacing"] = true
+L["Compact Text Layout"] = true
 L["Enable Custom Roll Frame"] = true
 L["Frame Spacing"] = true
+L["Frame Height"] = true
 L["Frame Width"] = true
 L["Height of the countdown timer bar"] = true
+L["Minimum height of the roll frame"] = true
 L["Inner padding of the roll frame"] = true
 L["Instance Filters"] = true
 L["Loot Roll"] = true
@@ -168,6 +171,7 @@ L["Show in Dungeons"] = true
 L["Show in Open World"] = true
 L["Show in Raids"] = true
 L["Show individual roll result notifications"] = true
+L["Show item name and bind type on the same line"] = true
 L["Show notifications for other group members' roll results"] = true
 L["Show notifications for your own roll results"] = true
 L["Show notifications when other group members win rolls"] = true
@@ -180,7 +184,21 @@ L["Spacing between multiple roll frames"] = true
 L["Spacing between roll buttons"] = true
 L["Timer Bar Height"] = true
 L["Timer Bar Spacing"] = true
+L["Timer Bar Style"] = true
+L["Normal"] = true
+L["Minimal"] = true
+L["Minimal Height"] = true
+L["Height of the minimal timer bar"] = true
+L["Timer Bar Appearance"] = true
+L["Timer Bar Border"] = true
+L["Timer Bar Border Color"] = true
 L["Timer Bar Texture"] = true
+L["Color Mode"] = true
+L["Custom"] = true
+L["Bar Color"] = true
+L["Bar Background"] = true
+L["Bar Background Opacity"] = true
+L["Show a border around the timer bar"] = true
 L["Vertical spacing between roll rows"] = true
 L["Width of the roll frame"] = true
 
@@ -192,6 +210,9 @@ L["History"] = true
 L["Max Entries"] = true
 L["Track Direct Loot"] = true
 L["Track items you pick up directly (not from a loot window)"] = true
+L["Roll Details"] = true
+L["Show Roll Details"] = true
+L["Click history entries to expand and see all player rolls"] = true
 
 -- DragonLoot_Options/Tabs/AutoLootTab.lua
 L["Auto-Loot"] = true
@@ -243,6 +264,8 @@ L["Slot Background"] = true
 L["Stripe"] = true
 L["Thick Outline"] = true
 L["Thickness of the frame border"] = true
+L["Text Shadow"] = true
+L["Enable text shadow on all text elements"] = true
 
 -- DragonLoot_Options/Tabs/AnimationTab.lua
 L["Animation"] = true

--- a/DragonLoot_Options/Tabs/AppearanceTab.lua
+++ b/DragonLoot_Options/Tabs/AppearanceTab.lua
@@ -104,7 +104,18 @@ local function CreateFontSection(parent, W, db, yOffset)
             LC.NotifyAppearanceChange()
         end,
     })
-    yOffset = LC.AnchorWidget(outlineDropdown, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+    yOffset = LC.AnchorWidget(outlineDropdown, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    local fontShadowToggle = W.CreateToggle(parent, {
+        label = L["Text Shadow"],
+        tooltip = L["Enable text shadow on all text elements"],
+        get = function() return db.profile.appearance.fontShadow end,
+        set = function(value)
+            db.profile.appearance.fontShadow = value
+            LC.NotifyAppearanceChange()
+        end,
+    })
+    yOffset = LC.AnchorWidget(fontShadowToggle, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
 
     return yOffset
 end

--- a/DragonLoot_Options/Tabs/HistoryTab.lua
+++ b/DragonLoot_Options/Tabs/HistoryTab.lua
@@ -90,6 +90,25 @@ local function CreateTogglesSection(parent, W, db, yOffset)
     -- Apply initial disabled state based on current trackDirectLoot value
     qualityDropdown:SetDisabled(not db.profile.history.trackDirectLoot)
 
+    -- Section gap
+    yOffset = yOffset - LC.SPACING_BETWEEN_SECTIONS + LC.SPACING_BETWEEN_WIDGETS
+
+    -- Roll Details header
+    local detailsHeader = W.CreateHeader(parent, L["Roll Details"])
+    yOffset = LC.AnchorWidget(detailsHeader, parent, yOffset) - LC.SPACING_AFTER_HEADER
+
+    -- Show Roll Details toggle
+    local rollDetailsToggle = W.CreateToggle(parent, {
+        label = L["Show Roll Details"],
+        tooltip = L["Click history entries to expand and see all player rolls"],
+        get = function() return db.profile.history.showRollDetails end,
+        set = function(value)
+            db.profile.history.showRollDetails = value
+            ApplyHistorySettings()
+        end,
+    })
+    yOffset = LC.AnchorWidget(rollDetailsToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
     return yOffset
 end
 

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -33,6 +33,20 @@ local function NotifyRollManager()
 end
 
 -------------------------------------------------------------------------------
+-- Timer bar color mode values
+-------------------------------------------------------------------------------
+
+local COLOR_MODE_VALUES = {
+    { value = "gradient", text = L["Gradient"] },
+    { value = "custom", text = L["Custom"] },
+}
+
+local TIMER_BAR_STYLE_VALUES = {
+    { value = "normal", text = L["Normal"] },
+    { value = "minimal", text = L["Minimal"] },
+}
+
+-------------------------------------------------------------------------------
 -- Section: Roll Frame (basic settings)
 -------------------------------------------------------------------------------
 
@@ -89,13 +103,62 @@ local function CreateLayoutSection(parent, W, db, yOffset, LC)
     yOffset = LC.AnchorWidget(header, parent, yOffset) - LC.SPACING_AFTER_HEADER
 
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
+        L["Frame Height"], L["Minimum height of the roll frame"], "frameMinHeight", 40, 120, 1, "%d")
+    yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f")
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Frame Width"], L["Width of the roll frame"], "frameWidth", 200, 500, 10, "%d")
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Row Spacing"], L["Vertical spacing between roll rows"], "rowSpacing", 0, 16, 1, "%d")
-    yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
-        L["Timer Bar Height"], L["Height of the countdown timer bar"], "timerBarHeight", 6, 24, 1, "%d")
+    -- Timer Bar Style dropdown + height sliders
+    local timerBarHeightSlider, minimalHeightSlider  -- forward declare
+
+    local styleDropdown = W.CreateDropdown(parent, {
+        label = L["Timer Bar Style"],
+        values = TIMER_BAR_STYLE_VALUES,
+        get = function() return db.profile.rollFrame.timerBarStyle end,
+        set = function(value)
+            db.profile.rollFrame.timerBarStyle = value
+            local isMinimal = (value == "minimal")
+            if timerBarHeightSlider then timerBarHeightSlider:SetDisabled(isMinimal) end
+            if minimalHeightSlider then minimalHeightSlider:SetDisabled(not isMinimal) end
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(styleDropdown, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    timerBarHeightSlider = W.CreateSlider(parent, {
+        label = L["Timer Bar Height"],
+        tooltip = L["Height of the countdown timer bar"],
+        min = 6,
+        max = 24,
+        step = 1,
+        format = "%d",
+        get = function() return db.profile.rollFrame.timerBarHeight end,
+        set = function(value)
+            db.profile.rollFrame.timerBarHeight = value
+            NotifyRollManager()
+        end,
+    })
+    timerBarHeightSlider:SetDisabled(db.profile.rollFrame.timerBarStyle == "minimal")
+    yOffset = LC.AnchorWidget(timerBarHeightSlider, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    minimalHeightSlider = W.CreateSlider(parent, {
+        label = L["Minimal Height"],
+        tooltip = L["Height of the minimal timer bar"],
+        min = 1,
+        max = 6,
+        step = 1,
+        format = "%d",
+        get = function() return db.profile.rollFrame.timerBarMinimalHeight end,
+        set = function(value)
+            db.profile.rollFrame.timerBarMinimalHeight = value
+            NotifyRollManager()
+        end,
+    })
+    minimalHeightSlider:SetDisabled(db.profile.rollFrame.timerBarStyle ~= "minimal")
+    yOffset = LC.AnchorWidget(minimalHeightSlider, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Timer Bar Spacing"], L["Space between item row and timer bar"], "timerBarSpacing", 0, 16, 1, "%d")
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
@@ -106,6 +169,17 @@ local function CreateLayoutSection(parent, W, db, yOffset, LC)
         L["Button Spacing"], L["Spacing between roll buttons"], "buttonSpacing", 0, 12, 1, "%d")
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Frame Spacing"], L["Spacing between multiple roll frames"], "frameSpacing", 0, 16, 1, "%d")
+
+    local compactToggle = W.CreateToggle(parent, {
+        label = L["Compact Text Layout"],
+        tooltip = L["Show item name and bind type on the same line"],
+        get = function() return db.profile.rollFrame.compactTextLayout end,
+        set = function(value)
+            db.profile.rollFrame.compactTextLayout = value
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(compactToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
 
     local textureDropdown = W.CreateDropdown(parent, {
         label = L["Timer Bar Texture"],
@@ -118,7 +192,104 @@ local function CreateLayoutSection(parent, W, db, yOffset, LC)
             NotifyRollManager()
         end,
     })
-    yOffset = LC.AnchorWidget(textureDropdown, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+    yOffset = LC.AnchorWidget(textureDropdown, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    -- Timer Bar Appearance sub-section
+    local timerBarHeader = W.CreateHeader(parent, L["Timer Bar Appearance"])
+    yOffset = LC.AnchorWidget(timerBarHeader, parent, yOffset) - LC.SPACING_AFTER_HEADER
+
+    local borderColorPicker  -- forward declare
+
+    local borderToggle = W.CreateToggle(parent, {
+        label = L["Timer Bar Border"],
+        tooltip = L["Show a border around the timer bar"],
+        get = function() return db.profile.rollFrame.timerBarBorder end,
+        set = function(value)
+            db.profile.rollFrame.timerBarBorder = value
+            if borderColorPicker then borderColorPicker:SetDisabled(not value) end
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(borderToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    borderColorPicker = W.CreateColorPicker(parent, {
+        label = L["Timer Bar Border Color"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarBorderColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarBorderColor.r = r
+            db.profile.rollFrame.timerBarBorderColor.g = g
+            db.profile.rollFrame.timerBarBorderColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    borderColorPicker:SetDisabled(not db.profile.rollFrame.timerBarBorder)
+    yOffset = LC.AnchorWidget(borderColorPicker, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    local barColorPicker  -- forward declare
+
+    local colorModeDropdown = W.CreateDropdown(parent, {
+        label = L["Color Mode"],
+        values = COLOR_MODE_VALUES,
+        get = function() return db.profile.rollFrame.timerBarColorMode end,
+        set = function(value)
+            db.profile.rollFrame.timerBarColorMode = value
+            if barColorPicker then barColorPicker:SetDisabled(value ~= "custom") end
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(colorModeDropdown, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    barColorPicker = W.CreateColorPicker(parent, {
+        label = L["Bar Color"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarColor.r = r
+            db.profile.rollFrame.timerBarColor.g = g
+            db.profile.rollFrame.timerBarColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    barColorPicker:SetDisabled(db.profile.rollFrame.timerBarColorMode ~= "custom")
+    yOffset = LC.AnchorWidget(barColorPicker, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    local bgColorPicker = W.CreateColorPicker(parent, {
+        label = L["Bar Background"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarBackgroundColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarBackgroundColor.r = r
+            db.profile.rollFrame.timerBarBackgroundColor.g = g
+            db.profile.rollFrame.timerBarBackgroundColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(bgColorPicker, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    local bgOpacitySlider = W.CreateSlider(parent, {
+        label = L["Bar Background Opacity"],
+        min = 0,
+        max = 1,
+        step = 0.05,
+        isPercent = true,
+        format = "%.0f",
+        get = function() return db.profile.rollFrame.timerBarBackgroundAlpha end,
+        set = function(value)
+            db.profile.rollFrame.timerBarBackgroundAlpha = value
+            NotifyRollManager()
+        end,
+    })
+    yOffset = LC.AnchorWidget(bgOpacitySlider, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
 
     return yOffset
 end


### PR DESCRIPTION
## Description

This adds 7 new visual customization options to DragonLoot, covering text rendering, roll frame layout, timer bar styling, and history frame detail expansion. All options have sensible defaults that preserve existing behavior - nothing changes unless the user opts in.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes

1. **Text Shadow Toggle** - Global on/off for font shadow across all text elements (loot, roll, history). Applied via `DisplayUtils.ApplyTextShadow`.
2. **Roll Frame Height Control** - Configurable minimum height for roll frames, letting users stretch frames for readability.
3. **Compact Text Layout** - Single-line "item name (bind type)" in roll frames instead of two separate lines.
4. **Timer Bar Border** - Optional border around the roll timer bar with a dedicated color picker.
5. **Timer Bar Color Control** - Choose between the default green-yellow-red gradient or a custom static color. Includes background color and opacity controls.
6. **Minimal Timer Bar Mode** - Full-width thin strip pinned to the bottom of the roll frame, replacing the inset bar.
7. **Per-Player Roll Details in History** - Expandable rows in the history frame showing individual roll results (player, roll type, roll value) for each loot entry.

## Related Issues

Closes #63

## Testing

- [x] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [ ] WoW version(s) tested on:

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format