### PR TITLE
fix: compact layout fixes and config UX improvements (#63)

### DIFF
--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -223,7 +223,7 @@ local function CreateEntryFrame()
 
     -- Detail container for expanded roll results
     entry.detailContainer = CreateFrame("Frame", nil, entry)
-    entry.detailContainer:SetPoint("TOPLEFT", entry.icon, "BOTTOMLEFT", 0, -2)
+    entry.detailContainer:SetPoint("TOPLEFT", entry, "TOPLEFT", 2, -GetEntryHeight())
     entry.detailContainer:SetPoint("RIGHT", entry, "RIGHT", 0, 0)
     entry.detailContainer:Hide()
 
@@ -408,6 +408,11 @@ local function PopulateEntryDetails(entry, rollResults)
 
     local fontPath, fontSize, fontOutline = GetFont()
     entry.detailRows = {}
+
+    -- Re-anchor detail container to account for icon size config changes since frame creation
+    entry.detailContainer:ClearAllPoints()
+    entry.detailContainer:SetPoint("TOPLEFT", entry, "TOPLEFT", 2, -GetEntryHeight())
+    entry.detailContainer:SetPoint("RIGHT", entry, "RIGHT", 0, 0)
 
     for idx, result in ipairs(rollResults) do
         local row = AcquireDetailRow(entry.detailContainer)

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -199,7 +199,7 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
             -- bindText sits to the left of the buttons
             frame.bindText:ClearAllPoints()
             frame.bindText:SetPoint("RIGHT", leftmostButton, "LEFT", -4, 0)
-            frame.bindText:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+            frame.bindText:SetPoint("TOP", frame, "TOP", 0, -(padding + borderSize))
 
             -- itemName fills remaining space, stopping before bindText
             frame.itemName:SetPoint("RIGHT", frame.bindText, "LEFT", -2, 0)

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -654,6 +654,8 @@ local function RenderRollFrame(frame, data, rollID, isTest)
 
     -- Item name
     frame.itemName:SetFont(fontPath, fontSize, fontOutline)
+    frame.bindText:SetFont(fontPath, fontSize, fontOutline)
+    frame.timerBar.text:SetFont(fontPath, fontSize, fontOutline)
     DU.ApplyFontShadow(frame.itemName, ns.Addon.db)
     DU.ApplyFontShadow(frame.bindText, ns.Addon.db)
     DU.ApplyFontShadow(frame.timerBar.text, ns.Addon.db)
@@ -985,6 +987,8 @@ function ns.RollFrame.ApplySettings()
 
             -- Update fonts
             frame.itemName:SetFont(fontPath, fontSize, fontOutline)
+            frame.bindText:SetFont(fontPath, fontSize, fontOutline)
+            frame.timerBar.text:SetFont(fontPath, fontSize, fontOutline)
             DU.ApplyFontShadow(frame.itemName, ns.Addon.db)
             DU.ApplyFontShadow(frame.bindText, ns.Addon.db)
             DU.ApplyFontShadow(frame.timerBar.text, ns.Addon.db)

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -177,6 +177,30 @@ local function GetTimerBarMinimalHeight()
     return ns.Addon.db.profile.rollFrame.timerBarMinimalHeight or 3
 end
 
+local function CalculateFrameHeight(iconSize)
+    local db = ns.Addon.db.profile
+    if db.rollFrame.compactTextLayout then
+        local padding = GetContentPadding()
+        local borderSize = db.appearance.borderSize or 1
+        local buttonSize = GetButtonSize()
+        local timerBarSpacing = GetTimerBarSpacing()
+        local timerBarHeight
+        if GetTimerBarStyle() == "minimal" then
+            timerBarHeight = GetTimerBarMinimalHeight()
+        else
+            timerBarHeight = (db.rollFrame.timerBarHeight or 12)
+        end
+        -- Content row must fit buttons or icon, whichever is taller
+        local contentRow = math.max(buttonSize, iconSize)
+        -- Top padding + content + spacing + timer bar + bottom padding
+        local fromContent = (padding + borderSize) + contentRow + timerBarSpacing + timerBarHeight + borderSize
+        -- Icon must also fit (vertically centered)
+        local fromIcon = iconSize + 2 * (padding + borderSize)
+        return math.max(fromContent, fromIcon)
+    end
+    return math.max(GetFrameMinHeight(), iconSize + ROLL_FRAME_EXTRA_HEIGHT)
+end
+
 local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderSize, rowSpacing)
     -- Item name top-left anchor (shared by both modes)
     frame.itemName:ClearAllPoints()
@@ -187,7 +211,7 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
         -- Compact: buttons sit on the same row as the item name
         frame.passButton:ClearAllPoints()
         frame.passButton:SetPoint("RIGHT", frame, "RIGHT", -(padding + borderSize), 0)
-        frame.passButton:SetPoint("TOP", frame.itemName, "TOP", 0, 0)
+        frame.passButton:SetPoint("TOP", frame, "TOP", 0, -(padding + borderSize))
 
         -- Determine leftmost button
         local leftmostButton = frame.needButton
@@ -639,7 +663,7 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     frame.iconFrame:SetSize(iconSize, iconSize)
 
     -- Adjust frame height based on icon size
-    frame:SetHeight(math.max(GetFrameMinHeight(), iconSize + ROLL_FRAME_EXTRA_HEIGHT))
+    frame:SetHeight(CalculateFrameHeight(iconSize))
 
     -- Icon
     frame.iconFrame.icon:SetTexture(data.texture)
@@ -960,8 +984,21 @@ function ns.RollFrame.ApplySettings()
                 frame.transmogButton:SetSize(btnSize, btnSize)
             end
 
+            -- Re-anchor button chain with current spacing
+            local btnSpacing = GetButtonSpacing()
+            frame.disenchantButton:ClearAllPoints()
+            frame.disenchantButton:SetPoint("RIGHT", frame.passButton, "LEFT", -btnSpacing, 0)
+            frame.greedButton:ClearAllPoints()
+            frame.greedButton:SetPoint("RIGHT", frame.disenchantButton, "LEFT", -btnSpacing, 0)
+            frame.needButton:ClearAllPoints()
+            frame.needButton:SetPoint("RIGHT", frame.greedButton, "LEFT", -btnSpacing, 0)
+            if frame.transmogButton then
+                frame.transmogButton:ClearAllPoints()
+                frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -btnSpacing, 0)
+            end
+
             -- Adjust frame height based on icon size
-            frame:SetHeight(math.max(GetFrameMinHeight(), iconSize + ROLL_FRAME_EXTRA_HEIGHT))
+            frame:SetHeight(CalculateFrameHeight(iconSize))
 
             -- Update layout offsets for border thickness
             ApplyLayoutOffsets(frame)

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -102,14 +102,46 @@ local function CreateLayoutSection(parent, W, db, yOffset, LC)
     local header = W.CreateHeader(parent, L["Layout"])
     yOffset = LC.AnchorWidget(header, parent, yOffset) - LC.SPACING_AFTER_HEADER
 
-    yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
-        L["Frame Height"], L["Minimum height of the roll frame"], "frameMinHeight", 40, 120, 1, "%d")
+    local frameMinHeightSlider, rowSpacingSlider  -- forward declare for compact toggle
+
+    local isCompact = db.profile.rollFrame.compactTextLayout
+
+    frameMinHeightSlider = W.CreateSlider(parent, {
+        label = L["Frame Height"],
+        tooltip = L["Minimum height of the roll frame"],
+        min = 40,
+        max = 120,
+        step = 1,
+        format = "%d",
+        get = function() return db.profile.rollFrame.frameMinHeight end,
+        set = function(value)
+            db.profile.rollFrame.frameMinHeight = value
+            NotifyRollManager()
+        end,
+    })
+    frameMinHeightSlider:SetDisabled(isCompact)
+    yOffset = LC.AnchorWidget(frameMinHeightSlider, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f")
     yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
         L["Frame Width"], L["Width of the roll frame"], "frameWidth", 200, 500, 10, "%d")
-    yOffset = CreateLayoutSlider(parent, W, db, yOffset, LC,
-        L["Row Spacing"], L["Vertical spacing between roll rows"], "rowSpacing", 0, 16, 1, "%d")
+
+    rowSpacingSlider = W.CreateSlider(parent, {
+        label = L["Row Spacing"],
+        tooltip = L["Vertical spacing between roll rows"],
+        min = 0,
+        max = 16,
+        step = 1,
+        format = "%d",
+        get = function() return db.profile.rollFrame.rowSpacing end,
+        set = function(value)
+            db.profile.rollFrame.rowSpacing = value
+            NotifyRollManager()
+        end,
+    })
+    rowSpacingSlider:SetDisabled(isCompact)
+    yOffset = LC.AnchorWidget(rowSpacingSlider, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
     -- Timer Bar Style dropdown + height sliders
     local timerBarHeightSlider, minimalHeightSlider  -- forward declare
 
@@ -176,6 +208,8 @@ local function CreateLayoutSection(parent, W, db, yOffset, LC)
         get = function() return db.profile.rollFrame.compactTextLayout end,
         set = function(value)
             db.profile.rollFrame.compactTextLayout = value
+            if frameMinHeightSlider then frameMinHeightSlider:SetDisabled(value) end
+            if rowSpacingSlider then rowSpacingSlider:SetDisabled(value) end
             NotifyRollManager()
         end,
     })


### PR DESCRIPTION
## Summary

Fixes bugs reported by LiamGBR in #63 after the 0.8.0 release, focusing on compact text layout mode, font settings, and history display.

Closes #63

## Changes

### Bug Fixes

**Compact layout circular anchor crash** (RollFrame.lua)
- Fixed TWO circular anchor chains that caused `SetPoint would result in anchor cycle` errors
- First: `bindText TOP → itemName` (commit 428811e)
- Second: `passButton TOP → itemName → bindText → needButton → ... → passButton` — passButton now anchors to `frame` directly

**Font settings not applied to all text** (RollFrame.lua)
- Font outline and size now applied to BoP/BoE bind text and timer bar text, not just item name

**History detail rows overlap** (HistoryFrame.lua)
- Fixed entry height calculation so detail rows don't overlap when expanded

### Improvements

**Compact mode auto-sizing** (RollFrame.lua)
- New `CalculateFrameHeight(iconSize)` helper computes tight frame height from actual content in compact mode
- Both `RenderRollFrame()` and `ApplySettings()` use this for consistent sizing

**Button spacing live update** (RollFrame.lua)
- Button chain re-anchored in `ApplySettings()` so `buttonSpacing` config changes take effect without `/reload`

**Config UX: disable irrelevant sliders** (LootRollTab.lua)
- Frame Height and Row Spacing sliders are now disabled when compact mode is enabled (they have no effect in compact mode)
- Follows existing pattern used by timer bar height/minimal height sliders

**LibAnimate submodule pin update**
- Updated submodule to `e9e9a18` after upstream force-push

## Testing

- [x] Luacheck passes (0 warnings / 0 errors)
- [ ] In-game: compact layout no longer crashes on `/dl testroll`
- [ ] In-game: compact frames auto-size correctly
- [ ] In-game: button spacing changes apply live
- [ ] In-game: frameMinHeight and rowSpacing sliders greyed out when compact is on
- [ ] In-game: font outline/size applied to bind text and timer text
- [ ] In-game: history entries don't overlap