### PR TITLE
fix: roll frame drag, confirm roll crash, and duplicate popup (#96)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,200 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# DragonLoot - Lua / WoW addon specific overrides.
+# Generic settings inherited from org-level .coderabbit.yaml
+
+language: en-US
+inheritance: true
+
+tone_instructions: >-
+  Review WoW addon Lua code. Focus on nil safety, global leaks,
+  event hygiene, and taint risks. Skip style - luacheck handles it.
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+  sequence_diagrams: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: true
+  auto_apply_labels: true
+  suggested_reviewers: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords:
+      - WIP
+      - DO NOT MERGE
+    drafts: false
+
+  labeling_instructions:
+    - label: core
+      instructions: >-
+        Apply when the PR changes files under DragonLoot/Core/ -
+        addon lifecycle, config, slash commands, minimap icon.
+    - label: display
+      instructions: >-
+        Apply when the PR changes files under DragonLoot/Display/ -
+        loot window, roll frame, history frame, animations, roll manager.
+    - label: listeners
+      instructions: >-
+        Apply when the PR changes files under DragonLoot/Listeners/ -
+        event handlers for loot, rolls, history, or CHAT_MSG_LOOT parsing.
+    - label: options
+      instructions: >-
+        Apply when the PR changes files under DragonLoot_Options/ -
+        config UI widgets, tabs, and layout.
+    - label: ci
+      instructions: >-
+        Apply when the PR changes files under .github/ -
+        workflows, issue templates, or PR templates.
+    - label: localization
+      instructions: >-
+        Apply when the PR changes files under DragonLoot/Locales/ -
+        translation tables for any language.
+
+  path_filters:
+    - "!DragonLoot/Libs/**"
+    - "!**/node_modules/**"
+    - "!**/*.snap"
+
+  path_instructions:
+    - path: "DragonLoot/Core/**/*.lua"
+      instructions: >-
+        Core addon layer - lifecycle, AceDB config, slash commands, minimap icon.
+        Review for correct AceAddon/AceEvent/AceTimer patterns, proper event
+        cleanup on OnDisable, and SavedVariables schema correctness.
+        All files use `local ADDON_NAME, ns = ...` shared namespace.
+    - path: "DragonLoot/Display/**/*.lua"
+      instructions: >-
+        Display layer - UI frames and presentation. Review for frame pool
+        hygiene (acquire/release), proper Show/Hide/SetShown patterns,
+        animation cleanup on hide, nil checks on widget methods, and
+        correct backdrop/border API usage (CreateFrame + BackdropTemplateMixin).
+        Frames must not leak globals. Check for taint risks in combat.
+    - path: "DragonLoot/Listeners/**/*.lua"
+      instructions: >-
+        Event listener layer - version-specific loot/roll/history parsing.
+        Key concerns: proper RegisterEvent/UnregisterEvent pairing, dedup
+        guards for duplicate event fires (e.g. LOOT_OPENED double-fire,
+        LOOT_HISTORY_UPDATE_ENCOUNTER re-fires), nil checks on WoW API
+        returns (GetItemInfo returns nil for uncached items - must handle
+        with retry timers). Retail and Classic listeners exist side-by-side
+        with WOW_PROJECT_ID version guards. Do not flag the guard pattern
+        as dead code.
+    - path: "DragonLoot/Listeners/LootHistoryChat.lua"
+      instructions: >-
+        CHAT_MSG_LOOT parser for direct loot tracking. GlobalString patterns
+        differ across game versions (TBC has trailing periods, Retail does not).
+        Patterns are built from actual GlobalString values at runtime.
+        Review for correct Lua pattern escaping and C_Timer.After retry
+        for uncached GetItemInfo calls.
+    - path: "DragonLoot_Options/**/*.lua"
+      instructions: >-
+        Config UI - custom widget library and option tabs. Review for
+        correct widget lifecycle (OnAcquire/OnRelease if pooled), proper
+        config key paths matching db.profile schema in Core/Config.lua,
+        and callback wiring. Uses CreateFrame-based widgets, not AceGUI.
+    - path: "DragonLoot/Locales/**/*.lua"
+      instructions: >-
+        Localization tables using AceLocale. Only flag missing keys
+        compared to enUS.lua or incorrect format string placeholders
+        (%s, %d, etc). Do not flag translation quality or grammar.
+    - path: ".github/workflows/**/*.yml"
+      instructions: >-
+        CI workflows. Check for correct event triggers (pull_request_target
+        for lint, workflow_dispatch for packager), proper secret references,
+        and action version pinning. BigWigsMods packager workflow has
+        specific requirements - do not flag its patterns.
+    - path: "**/*.md"
+      instructions: >-
+        Documentation. Only flag broken links or factual errors.
+        Do not suggest rewording or restructuring prose.
+    - path: ".luacheckrc"
+      instructions: >-
+        Luacheck configuration. Review for correct globals declarations
+        and rule settings. Do not suggest adding rules for style preferences
+        already handled by project conventions.
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: >-
+        PR title must use Conventional Commit format: type(scope): description.
+        Valid types: feat, fix, refactor, docs, chore, ci, test, style, perf.
+
+  tools:
+    # -- Keep universal tools --
+    github-checks:
+      enabled: true
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    languagetool:
+      enabled: false
+
+    # -- Disable: not a JS/TS/Python/Rust project --
+    biome:
+      enabled: false
+    eslint:
+      enabled: false
+    ruff:
+      enabled: false
+    flake8:
+      enabled: false
+    clippy:
+      enabled: false
+    hadolint:
+      enabled: false
+    swiftlint:
+      enabled: false
+    phpstan:
+      enabled: false
+    phpmd:
+      enabled: false
+    phpcs:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    checkov:
+      enabled: false
+    tflint:
+      enabled: false
+    detekt:
+      enabled: false
+    fortitudeLint:
+      enabled: false
+    rubocop:
+      enabled: false
+    buf:
+      enabled: false
+    regal:
+      enabled: false
+    pmd:
+      enabled: false
+    clang:
+      enabled: false
+    cppcheck:
+      enabled: false
+    semgrep:
+      enabled: false
+    circleci:
+      enabled: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@ DragonLoot is a customizable loot addon that replaces the default Blizzard loot 
 
 ---
 
+## Skills
+
+Agents working on this project must load the `wow-addon-dev` skill before writing or reviewing any Lua code that calls WoW APIs. The skill provides access to the `wow-api-lookup` tool for verifying API signatures, return values, widget methods, and enum values.
+
+**Rule**: Never guess at WoW API signatures. Always verify with `wow-api-lookup` first.
+
+---
+
 ## Target Versions
 
 | Version | Interface | TOC Directive |
@@ -140,6 +148,8 @@ All modules attach to `ns`:
 ---
 
 ## Version-Specific API Differences
+
+> **Note**: This table is a quick reference. Always verify exact signatures, parameter counts, and return types using the `wow-api-lookup` tool from the `wow-addon-dev` skill.
 
 | Aspect | Retail | Classic (TBC/Cata/MoP) |
 |--------|--------|------------------------|
@@ -517,6 +527,7 @@ local LSM = LibStub("LibSharedMedia-3.0")
 - Default to plain Lua 5.1 with no annotations
 - Only add LuaLS annotations when the file already uses them or for public library APIs
 - Keep annotations minimal and accurate; do not introduce new tooling
+- LuaLS annotations for WoW APIs are available via the `wow-addon-dev` skill for reference, but do not add them to addon source files unless already present
 
 ### Functions and Structure
 - Keep functions under 50 lines; extract helpers when longer
@@ -530,6 +541,7 @@ local LSM = LibStub("LibSharedMedia-3.0")
 - For version differences, prefer `or` fallbacks over runtime version checks
 - Use `pcall` for user callbacks or APIs that may be missing in some versions
 - Use `error(msg, 2)` for public library input validation (reports at caller site)
+- Always verify API signatures with `wow-api-lookup` before adding defensive checks - know what the API actually returns
 
 ---
 
@@ -635,6 +647,8 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 - If only manual tests exist, document what you verified in-game
 - Verify changes in the game client when possible
 - Keep changes small and focused; prefer composition over inheritance
+- Load the `wow-addon-dev` skill before writing or reviewing WoW API calls
+- Use `wow-api-lookup` to verify API signatures - never guess at parameter counts or return types
 
 ---
 

--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -107,6 +107,7 @@ end
 -- Events the default group roll frames listen for
 local ROLL_FRAME_EVENTS = {
     "START_LOOT_ROLL", "CANCEL_LOOT_ROLL",
+    "CONFIRM_LOOT_ROLL", "CONFIRM_DISENCHANT_ROLL",
 }
 
 local lootFrameHooked = false
@@ -136,6 +137,8 @@ local function SuppressBlizzardRollFrames()
     -- GroupLootContainer_AddRoll(), which re-shows GroupLootFrame1-4.
     UIParent:UnregisterEvent("START_LOOT_ROLL")
     UIParent:UnregisterEvent("CANCEL_LOOT_ROLL")
+    UIParent:UnregisterEvent("CONFIRM_LOOT_ROLL")
+    UIParent:UnregisterEvent("CONFIRM_DISENCHANT_ROLL")
 
     -- Belt-and-suspenders: also suppress the individual roll frames and container
     for i = 1, 4 do
@@ -164,6 +167,8 @@ local function RestoreBlizzardRollFrames()
     -- Restore UIParent dispatch so Blizzard roll frames work again
     UIParent:RegisterEvent("START_LOOT_ROLL")
     UIParent:RegisterEvent("CANCEL_LOOT_ROLL")
+    UIParent:RegisterEvent("CONFIRM_LOOT_ROLL")
+    UIParent:RegisterEvent("CONFIRM_DISENCHANT_ROLL")
 
     for i = 1, 4 do
         local frame = _G["GroupLootFrame" .. i]

--- a/DragonLoot/Core/SlashCommands.lua
+++ b/DragonLoot/Core/SlashCommands.lua
@@ -30,6 +30,8 @@ local HELP_ENTRIES = {
     { " reset",       L["Reset loot frame position"] },
     { " test",        L["Show test loot"] },
     { " testroll",    L["Show test roll frames"] },
+    { " testroll loop", L["Start continuous test roll spawning"] },
+    { " testroll stop", L["Stop continuous test roll spawning"] },
     { " history",     L["Toggle loot history"] },
     { " status",      L["Show current settings"] },
     { " help",        L["Show this help"] },
@@ -134,6 +136,20 @@ function ns.HandleSlashCommand(input)
             ns.LootFrame.ShowTestLoot()
         else
             ns.Print(L["Test loot not yet available."])
+        end
+
+    elseif cmd == "testroll loop" then
+        if ns.RollFrame.ShowTestRollLoop then
+            ns.RollFrame.ShowTestRollLoop()
+        else
+            ns.Print(L["Test roll not yet available."])
+        end
+
+    elseif cmd == "testroll stop" then
+        if ns.RollFrame.StopTestRollLoop then
+            ns.RollFrame.StopTestRollLoop()
+        else
+            ns.Print(L["Test roll not yet available."])
         end
 
     elseif cmd == "testroll" then

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -120,6 +120,8 @@ local TEST_ROLL_TICK_INTERVAL = 0.1
 local rollFramePool = {}
 local rollFrameCount = 0
 local anchorFrame
+local loopTicker
+local loopRollIndex = 0
 
 -------------------------------------------------------------------------------
 -- Backdrop and font wrappers (delegate to DisplayUtils)
@@ -886,6 +888,35 @@ local function StartTestTimer(frameIndex, duration)
 end
 
 -------------------------------------------------------------------------------
+-- Spawn a single random test roll into the next available slot
+-------------------------------------------------------------------------------
+
+local function SpawnOneTestRoll()
+    local freeIndex
+    for i = 1, MAX_VISIBLE_ROLLS do
+        local f = rollFramePool[i]
+        if not f or not f:IsShown() then
+            freeIndex = i
+            break
+        end
+    end
+    if not freeIndex then return end
+
+    loopRollIndex = loopRollIndex + 1
+    local testData = TEST_ROLLS[((loopRollIndex - 1) % #TEST_ROLLS) + 1]
+
+    local frame = AcquireRollFrame(freeIndex)
+    PopulateTestRollFrame(frame, testData)
+    frame:SetAlpha(0)
+    frame:Show()
+    LayoutRollFrames()
+    ns.RollAnimations.PlayShow(frame)
+
+    local duration = 8 + math.random() * 12
+    StartTestTimer(freeIndex, duration)
+end
+
+-------------------------------------------------------------------------------
 -- Public Interface: ns.RollFrame
 -------------------------------------------------------------------------------
 
@@ -1115,4 +1146,45 @@ function ns.RollFrame.ShowTestRoll()
     end
 
     ns.Print(L["Showing test roll frames."])
+end
+
+function ns.RollFrame.ShowTestRollLoop()
+    if loopTicker then
+        ns.RollFrame.StopTestRollLoop()
+        return
+    end
+
+    if not anchorFrame then
+        ns.RollFrame.Initialize()
+    end
+
+    SpawnOneTestRoll()
+
+    loopTicker = C_Timer.NewTicker(4, function()
+        SpawnOneTestRoll()
+    end)
+
+    ns.Print(L["Test roll loop started. Type /dl testroll stop to end."])
+end
+
+function ns.RollFrame.StopTestRollLoop()
+    if loopTicker then
+        loopTicker:Cancel()
+        loopTicker = nil
+    end
+
+    for i = 1, MAX_VISIBLE_ROLLS do
+        local f = rollFramePool[i]
+        if f and f.isTestMode then
+            if f.testTimer then
+                f.testTimer:Cancel()
+                f.testTimer = nil
+            end
+            ReleaseRollFrame(i)
+        end
+    end
+    LayoutRollFrames()
+
+    loopRollIndex = 0
+    ns.Print(L["Test roll loop stopped."])
 end

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -524,6 +524,25 @@ local function CreateRollFrame(index)
     frame:SetFrameLevel(110)
     frame:Hide()
 
+    -- Drag: propagate movement to the shared anchor frame
+    frame:EnableMouse(true)
+    frame:SetMovable(false)  -- frame itself doesn't move; anchor does
+    frame:RegisterForDrag("LeftButton")
+
+    frame:SetScript("OnDragStart", function()
+        local db = ns.Addon.db.profile.rollFrame
+        if not db.lock and anchorFrame then
+            anchorFrame:StartMoving()
+        end
+    end)
+
+    frame:SetScript("OnDragStop", function()
+        if anchorFrame then
+            anchorFrame:StopMovingOrSizing()
+            SaveFramePosition()
+        end
+    end)
+
     -- Item icon
     frame.iconFrame = CreateRollIcon(frame)
 

--- a/DragonLoot/Listeners/ListenerShared.lua
+++ b/DragonLoot/Listeners/ListenerShared.lua
@@ -13,7 +13,9 @@ local _, ns = ...
 
 local GetItemInfoInstant = GetItemInfoInstant
 local GetItemInfo = GetItemInfo
+local GetLootRollItemInfo = GetLootRollItemInfo
 local StaticPopup_Show = StaticPopup_Show
+local ITEM_QUALITY_COLORS = ITEM_QUALITY_COLORS
 
 -------------------------------------------------------------------------------
 -- Module table
@@ -114,7 +116,12 @@ function LS.OnCancelLootRoll(isRollActive, rollID)
 end
 
 function LS.OnConfirmRoll(rollID, rollType)
-    local dialog = StaticPopup_Show("DRAGONLOOT_CONFIRM_LOOT_ROLL")
+    local _, name, _, quality = GetLootRollItemInfo(rollID)
+    local coloredName = name or "Unknown"
+    if name and ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality] then
+        coloredName = ITEM_QUALITY_COLORS[quality].hex .. name .. "|r"
+    end
+    local dialog = StaticPopup_Show("DRAGONLOOT_CONFIRM_LOOT_ROLL", coloredName)
     if dialog then
         dialog.data = { rollID = rollID, rollType = rollType }
     end

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -82,8 +82,15 @@ L["Unknown"] = true
 L["Not available for this item"] = true
 L["Roll"] = true
 L["Showing test roll frames."] = true
+L["Start continuous test roll spawning"] = true
+L["Start or stop continuous test roll spawning"] = true
+L["Stop continuous test roll spawning"] = true
 L["Test Item"] = true
+L["Test Loop"] = true
+L["Test Roll"] = true
 L["Test item: "] = true
+L["Test roll loop started. Type /dl testroll stop to end."] = true
+L["Test roll loop stopped."] = true
 L["Test roll: "] = true
 
 -- Display/HistoryFrame.lua

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -71,7 +71,33 @@ local function CreateRollFrameSection(parent, W, db, yOffset, LC)
         get = function() return db.profile.rollFrame.lock end,
         set = function(value) db.profile.rollFrame.lock = value end,
     })
-    yOffset = LC.AnchorWidget(lockToggle, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+    yOffset = LC.AnchorWidget(lockToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
+    local testRollBtn = W.CreateButton(parent, {
+        text = L["Test Roll"],
+        width = 100,
+        tooltip = L["Show test roll frames"],
+        onClick = function()
+            if dlns.RollFrame and dlns.RollFrame.ShowTestRoll then
+                dlns.RollFrame.ShowTestRoll()
+            end
+        end,
+    })
+    testRollBtn:SetPoint("TOPLEFT", parent, "TOPLEFT", LC.PADDING_SIDE, yOffset)
+
+    local testLoopBtn = W.CreateButton(parent, {
+        text = L["Test Loop"],
+        width = 100,
+        tooltip = L["Start or stop continuous test roll spawning"],
+        onClick = function()
+            if dlns.RollFrame and dlns.RollFrame.ShowTestRollLoop then
+                dlns.RollFrame.ShowTestRollLoop()
+            end
+        end,
+    })
+    testLoopBtn:SetPoint("LEFT", testRollBtn, "RIGHT", 8, 0)
+
+    yOffset = yOffset - testRollBtn:GetHeight() - LC.SPACING_BETWEEN_SECTIONS
 
     return yOffset
 end


### PR DESCRIPTION
## Summary

Fixes three bugs reported by MrFIXlT on CurseForge (Mists Classic). All affect multiple game versions.

Closes #96

## Changes

### Bug Fix: Roll frames not movable
- Added drag propagation handlers to each visible roll frame in `CreateRollFrame()`
- Dragging any roll frame now moves the shared anchor frame (same pattern as LootFrame)
- Respects `rollFrame.lock` config and persists position

### Bug Fix: CONFIRM_LOOT_ROLL crash (SetFormattedText nil)
- `LS.OnConfirmRoll()` now calls `GetLootRollItemInfo(rollID)` to fetch item name and quality
- Builds quality-colored item name string via `ITEM_QUALITY_COLORS`
- Passes colored name to `StaticPopup_Show()` as format argument
- Falls back to "Unknown" if API returns nil

### Bug Fix: Duplicate confirmation popups
- Added `CONFIRM_LOOT_ROLL` and `CONFIRM_DISENCHANT_ROLL` to `ROLL_FRAME_EVENTS` in Init.lua
- `SuppressBlizzardRollFrames()` now unregisters both events from UIParent
- `RestoreBlizzardRollFrames()` now re-registers both events on disable

### Enhancement: Test roll loop mode
- `/dl testroll loop` starts continuous test roll spawning (every 4s, random 8-20s durations)
- `/dl testroll stop` stops the loop and clears all test frames
- Added "Test Roll" and "Test Loop" buttons in the Roll Frame config tab

## Testing

- [x] `/dl testroll` - single test roll appears, buttons work
- [x] `/dl testroll loop` - continuous rolls spawn every 4s
- [x] `/dl testroll stop` - loop stops, frames clear
- [x] Drag a roll frame - frame group moves, position persists across reload
- [x] Lock roll frames in config - drag is blocked
- [x] Trigger CONFIRM_LOOT_ROLL (roll Need on non-guaranteed drop) - popup shows item name in quality color
- [x] No duplicate Blizzard popup appears alongside DragonLoot's
- [x] Disable DragonLoot roll frame - Blizzard frames and popups restored correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Roll frames are now draggable to customize positioning on-screen.
  * Added continuous test roll spawning feature for testing via slash commands or options panel.
  * Improved loot roll confirmation display with colored item names.
  * Added "Test Roll" and "Test Loop" buttons to the options panel for easier testing.

* **Chores**
  * Added code review automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->