### PR TITLE
feat: add hide roll frame after voting option (#88)

### DIFF
--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -52,6 +52,7 @@ local defaults = {
             frameSpacing = 4,
             frameMinHeight = 68,
             compactTextLayout = false,
+            hideOnVote = false,
             timerBarStyle = "normal",
             timerBarMinimalHeight = 3,
         },

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -347,7 +347,20 @@ local function OnRollButtonClick(self)
         return
     end
     if frame.rollID then
+        -- Mark pending hide BEFORE RollOnLoot; synchronous CONFIRM_LOOT_ROLL
+        -- will clear the flag if a confirmation popup is needed.
+        local db = ns.Addon.db
+        local shouldHide = db and db.profile.rollFrame.hideOnVote
+        if shouldHide then
+            ns.RollManager.MarkPendingHide(frame.rollID)
+        end
+
         RollOnLoot(frame.rollID, self.rollType)
+
+        -- Hide now unless CONFIRM_LOOT_ROLL intercepted (flag cleared)
+        if shouldHide then
+            ns.RollManager.TryHideAfterVote(frame.rollID)
+        end
     end
 end
 

--- a/DragonLoot/Display/RollManager.lua
+++ b/DragonLoot/Display/RollManager.lua
@@ -87,6 +87,7 @@ local notifiedRolls = {}    -- rollID -> true (prevent duplicate winner notifica
 local activeRollCount = 0
 local timerHandle
 local lifecycleState = LifecycleUtil.CreateState()
+local HideAfterVote         -- forward declaration; defined after helpers
 
 -------------------------------------------------------------------------------
 -- StaticPopup for roll confirmations (shared by Retail and Classic listeners)
@@ -99,6 +100,11 @@ StaticPopupDialogs["DRAGONLOOT_CONFIRM_LOOT_ROLL"] = {
     OnAccept = function(self)
         if not self.data then return end
         ConfirmLootRoll(self.data.rollID, self.data.rollType)
+        -- Hide frame after confirming BoP roll if configured
+        local db = ns.Addon.db
+        if db and db.profile.rollFrame.hideOnVote then
+            HideAfterVote(self.data.rollID)
+        end
     end,
     timeout = 0,
     whileDead = 1,
@@ -140,7 +146,9 @@ local function OnTimerTick()
     for _, roll in pairs(activeRolls) do
         local elapsed = now - roll.startTime
         local timeLeft = max(0, roll.rollTime - elapsed)
-        ns.RollFrame.UpdateTimer(roll.frameIndex, timeLeft, roll.rollTime)
+        if roll.frameIndex then
+            ns.RollFrame.UpdateTimer(roll.frameIndex, timeLeft, roll.rollTime)
+        end
         -- Timer expired - Blizzard will send CANCEL_LOOT_ROLL, don't remove here
         if timeLeft <= 0 then -- luacheck: ignore 542
             -- Wait for the event
@@ -436,18 +444,24 @@ function ns.RollManager.CancelRoll(rollID)
 
         activeRolls[rollID] = nil
         notifiedRolls[rollID] = nil
-        activeRollCount = activeRollCount - 1
-        if activeRollCount <= 0 then
-            activeRollCount = 0
-            StopTimer()
-        end
 
-        -- Defer frame release and queue promotion until hide animation completes
-        ns.RollFrame.HideRoll(frameIndex, LifecycleUtil.Guard(lifecycleState, lifecycleToken, function()
-            if activeRolls[rollID] then return end
-            ReleaseFrameIndex(frameIndex)
+        if frameIndex then
+            activeRollCount = activeRollCount - 1
+            if activeRollCount <= 0 then
+                activeRollCount = 0
+                StopTimer()
+            end
+
+            -- Defer frame release and queue promotion until hide animation completes
+            ns.RollFrame.HideRoll(frameIndex, LifecycleUtil.Guard(lifecycleState, lifecycleToken, function()
+                if activeRolls[rollID] then return end
+                ReleaseFrameIndex(frameIndex)
+                PromoteFromQueue()
+            end))
+        else
+            -- votedAndHidden: no frame to hide, just clean up state and promote
             PromoteFromQueue()
-        end))
+        end
 
         return
     end
@@ -459,7 +473,9 @@ end
 function ns.RollManager.CancelAllRolls()
     for rollID, roll in pairs(activeRolls) do
         activeRolls[rollID] = nil
-        ReleaseFrameIndex(roll.frameIndex)
+        if roll.frameIndex then
+            ReleaseFrameIndex(roll.frameIndex)
+        end
     end
     activeRollCount = 0
     wipe(waitingRolls)
@@ -513,6 +529,40 @@ end
 
 function ns.RollManager.IsNotified(rollID)
     return notifiedRolls[rollID] or false
+end
+
+HideAfterVote = function(rollID)
+    local roll = activeRolls[rollID]
+    if not roll or not roll.frameIndex then return end
+
+    local frameIndex = roll.frameIndex
+    roll.frameIndex = nil
+    roll.votedAndHidden = true
+
+    activeRollCount = activeRollCount - 1
+    if activeRollCount <= 0 then
+        activeRollCount = 0
+        StopTimer()
+    end
+
+    local token = LifecycleUtil.CaptureToken(lifecycleState)
+    ns.RollFrame.HideRoll(frameIndex, LifecycleUtil.Guard(lifecycleState, token, function()
+        ReleaseFrameIndex(frameIndex)
+        PromoteFromQueue()
+    end))
+end
+
+function ns.RollManager.MarkPendingHide(rollID)
+    local roll = activeRolls[rollID]
+    if not roll then return end
+    roll.pendingHideAfterVote = true
+end
+
+function ns.RollManager.TryHideAfterVote(rollID)
+    local roll = activeRolls[rollID]
+    if not roll or not roll.pendingHideAfterVote then return end
+    roll.pendingHideAfterVote = nil
+    HideAfterVote(rollID)
 end
 
 function ns.RollManager.OnLootItemRollWon(itemLink, rollType, rollValue)

--- a/DragonLoot/Listeners/ListenerShared.lua
+++ b/DragonLoot/Listeners/ListenerShared.lua
@@ -116,6 +116,12 @@ function LS.OnCancelLootRoll(isRollActive, rollID)
 end
 
 function LS.OnConfirmRoll(rollID, rollType)
+    -- Clear pending hide-after-vote so the frame stays visible for confirmation
+    local roll = ns.RollManager.GetActiveRolls()[rollID]
+    if roll then
+        roll.pendingHideAfterVote = nil
+    end
+
     local _, name, _, quality = GetLootRollItemInfo(rollID)
     local coloredName = name or "Unknown"
     if name and ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality] then

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -178,6 +178,9 @@ L["Show in Dungeons"] = true
 L["Show in Open World"] = true
 L["Show in Raids"] = true
 L["Show individual roll result notifications"] = true
+L["Hide After Voting"] = true
+L["Hide the roll frame after you cast your vote. The roll continues in the background"
+    .. " and notifications still fire."] = true
 L["Show item name and bind type on the same line"] = true
 L["Show notifications for other group members' roll results"] = true
 L["Show notifications for your own roll results"] = true

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -73,6 +73,15 @@ local function CreateRollFrameSection(parent, W, db, yOffset, LC)
     })
     yOffset = LC.AnchorWidget(lockToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
 
+    local hideOnVoteToggle = W.CreateToggle(parent, {
+        label = L["Hide After Voting"],
+        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background"
+            .. " and notifications still fire."],
+        get = function() return db.profile.rollFrame.hideOnVote end,
+        set = function(value) db.profile.rollFrame.hideOnVote = value end,
+    })
+    yOffset = LC.AnchorWidget(hideOnVoteToggle, parent, yOffset) - LC.SPACING_BETWEEN_WIDGETS
+
     local testRollBtn = W.CreateButton(parent, {
         text = L["Test Roll"],
         width = 100,


### PR DESCRIPTION
## Summary

Adds a new "Hide After Voting" option to the Loot Roll configuration tab. When enabled, roll frames disappear after the player casts their vote, while the roll continues tracking in the background for notifications and winner resolution.

Closes #88

## Changes

- **Config.lua**: Added `hideOnVote = false` default in rollFrame profile
- **RollManager.lua**: New `HideAfterVote()` function that nils the frameIndex, decrements activeRollCount, releases the frame slot, and hides with animation. Guarded `OnTimerTick`, `CancelRoll`, and `CancelAllRolls` for nil frameIndex on votedAndHidden rolls
- **RollFrame.lua**: After `RollOnLoot()` in `OnRollButtonClick`, checks `hideOnVote` config and calls `HideAfterVote`
- **LootRollTab.lua**: Added toggle widget in Roll Frame section
- **enUS.lua**: Added locale strings for label and tooltip

## Testing

- [ ] Enable hideOnVote in config, queue for group loot
- [ ] Vote on a roll - verify frame hides immediately with animation
- [ ] Verify winner notification still fires after hidden roll resolves
- [ ] Verify queue promotion works (hide a frame, queued roll promotes)
- [ ] Verify timer expiry on hidden roll still triggers CancelRoll cleanup
- [ ] Disable hideOnVote - verify normal behavior (frame stays until resolved)
- [ ] Test mode (`/dl testroll`) - verify unaffected by hideOnVote
- [ ] Luacheck passes with 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Hide After Voting" toggle in Roll Frame settings (off by default). When enabled, the roll frame automatically hides after you cast your vote while the roll continues and notifications still fire.

* **Bug Fixes**
  * Roll frames are now reliably released and no longer linger after hiding or cancellation, preventing stale timers and UI artifacts.

* **Localization**
  * Added English text for the new setting and its description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->