### PR TITLE
fix: use correct atlas for transmog roll button (#94)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -63,6 +63,7 @@ files["DragonLoot/"] = {
         "GetLootRollItemInfo", "GetLootRollItemLink", "RollOnLoot", "GetLootRollTimeLeft",
         "GetActiveLootRollIDs", "ConfirmLootRoll",
         "HandleModifiedItemClick",
+        "C_Texture",
 
         -- WoW API - Loot History
         "C_LootHistory",

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -19,6 +19,7 @@ local GetLootRollItemInfo = GetLootRollItemInfo
 local GetLootRollItemLink = GetLootRollItemLink
 local RollOnLoot = RollOnLoot
 local HandleModifiedItemClick = HandleModifiedItemClick
+local C_Texture = C_Texture
 
 local LSM = LibStub("LibSharedMedia-3.0")
 local L = ns.L
@@ -92,6 +93,18 @@ local TEST_ROLLS = {
         canDisenchant = true,
         canTransmog = false,
         duration = 20,
+    },
+    {
+        texture = 133280,           -- Blazefury, Reborn (fire sword icon)
+        name = "Blazefury, Reborn",
+        count = 1,
+        quality = 4,                -- Epic
+        bindOnPickUp = true,
+        canNeed = true,
+        canGreed = false,           -- Greed disabled when Transmog available
+        canDisenchant = true,
+        canTransmog = true,
+        duration = 15,
     },
 }
 
@@ -592,8 +605,10 @@ local function CreateRollFrame(index)
 
     -- Transmog button - only functional on Retail where canTransmog is returned
     frame.transmogButton = CreateRollButton(frame, nil, ROLL_TRANSMOG, GetButtonSize())
-    local success = pcall(function() frame.transmogButton.icon:SetAtlas("transmog-icon-small") end)
-    if not success then
+    -- Use Blizzard's loot roll transmog atlas; fall back to disenchant icon if atlas missing (Classic)
+    if C_Texture and C_Texture.GetAtlasInfo and C_Texture.GetAtlasInfo("lootroll-toast-icon-transmog-up") then
+        frame.transmogButton.icon:SetAtlas("lootroll-toast-icon-transmog-up")
+    else
         frame.transmogButton.icon:SetTexture("Interface\\ICONS\\INV_Enchant_Disenchant")
     end
     frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -GetButtonSpacing(), 0)
@@ -761,8 +776,11 @@ local function RenderRollFrame(frame, data, rollID, isTest)
         if data.canTransmog then
             frame.transmogButton:Show()
             SetButtonState(frame.transmogButton, true, nil)
+            -- Match Blizzard: Transmog replaces Greed
+            frame.greedButton:Hide()
         else
             frame.transmogButton:Hide()
+            frame.greedButton:Show()
         end
     end
 


### PR DESCRIPTION
## Summary

Fixes the transmog button being invisible (present but blank) in the roll frame, reported in #94.

## Root Cause

The atlas name `transmog-icon-small` does not exist in the WoW atlas system. `SetAtlas` silently fails for non-existent atlas names (no error thrown), so the `pcall` wrapper always succeeded and the fallback texture was never applied. The button occupied layout space but had no visible icon.

## Changes

- **Correct atlas**: Use `lootroll-toast-icon-transmog-up` (from Blizzard `GroupLootFrame.xml`)
- **Proper validation**: Replace useless `pcall` with `C_Texture.GetAtlasInfo` check (returns nil for invalid atlas names). Triple-guarded for Classic compatibility where `C_Texture` may not exist
- **Greed/Transmog mutual exclusivity**: Hide Greed button when Transmog is shown, matching Blizzard GroupLootFrame behavior. Explicitly re-show Greed on frame pool reuse for non-transmog items
- **Test data**: Add third TEST_ROLLS entry with `canTransmog = true` so `/dl testroll` exercises the transmog button
- **.luacheckrc**: Add `C_Texture` to read_globals

## Testing

- `/dl testroll` now shows 3 roll frames, one with a visible transmog button and hidden greed button
- luacheck: 0 warnings, 0 errors across 56 files

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transmog button icon rendering in loot roll frames with enhanced fallback support for missing textures
  * Enhanced loot roll interface to properly manage button visibility and interactions based on transmog availability
  * Updated transmog-capable item handling in roll displays to prevent conflicting button states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->