### PR TITLE
chore: migrate to structured label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: Report a bug with DragonLoot
 title: "[Bug]: "
 labels:
-  - bug
+  - C-Bug
 body:
   - type: textarea
     id: description
@@ -43,8 +43,9 @@ body:
       description: Which version of World of Warcraft are you playing?
       options:
         - Retail
-        - TBC Anniversary
+        - Cata Classic
         - MoP Classic
+        - TBC Anniversary
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Suggest a new feature or improvement for DragonLoot
 title: "[Feature]: "
 labels:
-  - enhancement
+  - C-Feature
 assignees: []
 body:
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,8 +554,8 @@ Create issues using the repo's issue templates (`.github/ISSUE_TEMPLATE/`):
 
 Create via CLI:
 ```bash
-gh issue create --repo <ORG>/<REPO> --label "bug" --title "[Bug]: <title>" --body "<body matching template fields>"
-gh issue create --repo <ORG>/<REPO> --label "enhancement" --title "[Feature]: <title>" --body "<body matching template fields>"
+gh issue create --repo <ORG>/<REPO> --label "C-Bug" --title "[Bug]: <title>" --body "<body matching template fields>"
+gh issue create --repo <ORG>/<REPO> --label "C-Feature" --title "[Feature]: <title>" --body "<body matching template fields>"
 ```
 
 ### Branches


### PR DESCRIPTION
## Summary

Migrates DragonLoot's GitHub labels from flat defaults to a structured, prefixed taxonomy inspired by Bevy's label system.

## Changes

- **Issue templates**: Updated `bug-report.yml` to use `C-Bug` label (was `bug`), added Cata Classic to WoW version dropdown. Updated `feature-request.yml` to use `C-Feature` label (was `enhancement`).
- **AGENTS.md**: Updated CLI examples to reference new label names (`C-Bug`, `C-Feature`).
- **GitHub labels** (already applied via CLI):
  - Created 31 new prefixed labels (A-, C-, D-, P-, S- categories)
  - Re-labeled all 9 open issues with new taxonomy
  - Deleted 14 replaced old labels
  - Kept 4 labels as-is (autorelease: pending/tagged, breaking-change, help wanted)

## Testing

- Verified all 31 labels created successfully
- Verified all 9 open issues re-labeled correctly
- Verified old labels deleted without errors
- YAML template syntax validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized issue template labels: bug reports now use `C-Bug` instead of `bug`, feature requests use `C-Feature` instead of `enhancement`.
  * Updated bug report template: added `Cata Classic` to WoW Version options and reordered `TBC Anniversary`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->