### PR TITLE
fix: highlight roll button icon on hover instead of grey box (#86)

### DIFF
--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -494,9 +494,9 @@ local function CreateRollButton(parent, texture, rollType, size)
     btn.icon:SetAllPoints()
     btn.icon:SetTexture(texture)
 
-    btn.highlight = btn:CreateTexture(nil, "HIGHLIGHT")
-    btn.highlight:SetAllPoints()
-    btn.highlight:SetColorTexture(1, 1, 1, 0.2)
+    if texture then
+        btn:SetHighlightTexture(texture, "ADD")
+    end
 
     btn:SetScript("OnClick", OnRollButtonClick)
     btn:SetScript("OnEnter", OnRollButtonEnter)
@@ -614,8 +614,13 @@ local function CreateRollFrame(index)
     -- Use Blizzard's loot roll transmog atlas; fall back to disenchant icon if atlas missing (Classic)
     if C_Texture and C_Texture.GetAtlasInfo and C_Texture.GetAtlasInfo("lootroll-toast-icon-transmog-up") then
         frame.transmogButton.icon:SetAtlas("lootroll-toast-icon-transmog-up")
+        frame.transmogButton:SetHighlightAtlas("lootroll-toast-icon-transmog-up", "ADD")
+        local hl = frame.transmogButton:GetHighlightTexture()
+        hl:ClearAllPoints()
+        hl:SetAllPoints(frame.transmogButton.icon)
     else
         frame.transmogButton.icon:SetTexture("Interface\\ICONS\\INV_Enchant_Disenchant")
+        frame.transmogButton:SetHighlightTexture("Interface\\ICONS\\INV_Enchant_Disenchant", "ADD")
     end
     frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -GetButtonSpacing(), 0)
     frame.transmogButton:Hide()


### PR DESCRIPTION
## Summary
Replace the flat grey box hover effect on roll buttons with an additive icon glow using WoW's native `SetHighlightTexture` API.

## Changes
- `RollFrame.lua`: Removed manual `HIGHLIGHT`-layer white texture from `CreateRollButton`
- `RollFrame.lua`: Added `btn:SetHighlightTexture(texture, "ADD")` for Need/Greed/DE/Pass buttons - the engine now handles hover show/hide with an additive glow over the icon
- `RollFrame.lua`: Added `SetHighlightTexture` for the transmog button fallback path (Classic only; Retail atlas icon has no matching file-path equivalent)

## Testing
- luacheck: 0 new warnings
- Visual: hover over any roll button should now show a bright icon glow instead of a grey overlay box

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button highlight rendering in roll frames to display conditionally based on texture availability
  * Improved transmog button visual handling when using fallback icons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->