### PR TITLE
feat: show item level overlay on roll frame icon (#92)

### DIFF
--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -78,6 +78,7 @@ local defaults = {
             rollIconSize = 36,
             historyIconSize = 24,
             qualityBorder = true,
+            showItemLevel = true,
             slotBackground = "gradient",
             backgroundColor = { r = 0.05, g = 0.05, b = 0.05 },
             backgroundAlpha = 0.9,

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -20,6 +20,7 @@ local GetLootRollItemLink = GetLootRollItemLink
 local RollOnLoot = RollOnLoot
 local HandleModifiedItemClick = HandleModifiedItemClick
 local C_Texture = C_Texture
+local C_Item = C_Item
 
 local LSM = LibStub("LibSharedMedia-3.0")
 local L = ns.L
@@ -777,6 +778,38 @@ local function RenderRollFrame(frame, data, rollID, isTest)
         frame.iconFrame.count:Hide()
     end
 
+    -- Item level overlay on icon (bottom-left corner)
+    if ns.Addon.db.profile.appearance.showItemLevel and not isTest then
+        local link = GetLootRollItemLink(rollID)
+        local ilvl = link and C_Item and C_Item.GetDetailedItemLevelInfo and
+            C_Item.GetDetailedItemLevelInfo(link)
+        if not frame.iconFrame.ilvl then
+            frame.iconFrame.ilvl = frame.iconFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+            frame.iconFrame.ilvl:SetPoint("BOTTOMLEFT", frame.iconFrame, "BOTTOMLEFT", 2, 2)
+        end
+        if ilvl then
+            frame.iconFrame.ilvl:SetText(ilvl)
+            frame.iconFrame.ilvl:Show()
+        else
+            -- Item data not cached yet; retry after a short delay
+            frame.iconFrame.ilvl:Hide()
+            local capturedRollID = rollID
+            C_Timer.After(0.5, function()
+                if not frame or not frame:IsShown() then return end
+                if frame.rollID ~= capturedRollID then return end
+                local retryLink = GetLootRollItemLink(capturedRollID)
+                local retryIlvl = retryLink and C_Item and C_Item.GetDetailedItemLevelInfo and
+                    C_Item.GetDetailedItemLevelInfo(retryLink)
+                if retryIlvl and frame.iconFrame.ilvl then
+                    frame.iconFrame.ilvl:SetText(retryIlvl)
+                    frame.iconFrame.ilvl:Show()
+                end
+            end)
+        end
+    elseif frame.iconFrame.ilvl then
+        frame.iconFrame.ilvl:Hide()
+    end
+
     -- Button states
     SetButtonState(frame.needButton, data.canNeed, data.reasonNeed)
     SetButtonState(frame.greedButton, data.canGreed, data.reasonGreed)
@@ -1131,6 +1164,23 @@ function ns.RollFrame.ApplySettings()
                     frame.iconFrame.border:Show()
                 else
                     frame.iconFrame.border:Hide()
+                end
+            end
+
+            -- Update item level overlay visibility
+            if frame.iconFrame.ilvl then
+                if appearance.showItemLevel and frame.rollID and frame:IsShown() then
+                    local link = GetLootRollItemLink(frame.rollID)
+                    local ilvl = link and C_Item and C_Item.GetDetailedItemLevelInfo and
+                        C_Item.GetDetailedItemLevelInfo(link)
+                    if ilvl then
+                        frame.iconFrame.ilvl:SetText(ilvl)
+                        frame.iconFrame.ilvl:Show()
+                    else
+                        frame.iconFrame.ilvl:Hide()
+                    end
+                else
+                    frame.iconFrame.ilvl:Hide()
                 end
             end
         end

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -69,6 +69,8 @@ L["Quest"] = true
 L["Showing test loot window."] = true
 L["Test slot clicked: "] = true
 L["iLvl"] = true
+L["Show Item Level"] = true
+L["Show item level overlay on roll frame icon"] = true
 
 -- Display/RollManager.lua (shared roll-type labels via ns.RollTypeNames)
 L["Disenchant"] = true

--- a/DragonLoot_Options/Tabs/AppearanceTab.lua
+++ b/DragonLoot_Options/Tabs/AppearanceTab.lua
@@ -195,6 +195,17 @@ local function CreateIconSection(parent, db, yOffset)
     })
     innerY = LC.AnchorWidget(qualityBorderToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
+    local itemLevelToggle = W.CreateToggle(content, {
+        label = L["Show Item Level"],
+        tooltip = L["Show item level overlay on roll frame icon"],
+        get = function() return db.profile.appearance.showItemLevel end,
+        set = function(value)
+            db.profile.appearance.showItemLevel = value
+            LC.NotifyAppearanceChange()
+        end,
+    })
+    innerY = LC.AnchorWidget(itemLevelToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
     local slotBgDropdown = W.CreateDropdown(content, {
         label = L["Slot Background"],
         values = SLOT_BG_VALUES,


### PR DESCRIPTION
## Summary

Displays the item level (ilvl) as a small overlay on the bottom-left corner of the roll frame icon, giving players the key context they need when deciding to Need/Greed. Controlled by a new toggle in the Appearance options tab.

## Details

- New `appearance.showItemLevel` config key (default: `true`)
- Uses `GetLootRollItemLink` -> `C_Item.GetDetailedItemLevelInfo` for the effective (upgraded) ilvl, matching what the item tooltip shows
- Nil-safe defensive chain handles Classic versions where `C_Item` may be absent
- Retry timer (0.5s) handles items not yet in client cache, with stale-frame guard
- Test mode correctly skips the overlay (no synthetic roll IDs passed to WoW API)
- `ApplySettings` live-updates the overlay when the toggle is changed in Options
- Overlay uses `NumberFontNormal` (same as the stack count overlay), lazy-created once per frame

## Type of change

- [x] New feature (non-breaking)

## Testing

- `luacheck` passes with 0 new warnings
- Toggle visible in Appearance tab, live-updates on existing roll frames

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Item level information now displays as an overlay on roll frame icons, giving you immediate visibility of loot quality without needing to inspect individual items.
  * New "Show Item Level" toggle added to the Appearance settings tab, allowing you to customize the visibility of item level overlays on roll icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->