### PR TITLE
fix: correct DragonWidgets TOC paths and guard CONFIRM_DISENCHANT_ROLL on Classic

### DIFF
--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -106,10 +106,13 @@ end
 -------------------------------------------------------------------------------
 
 -- Events the default group roll frames listen for
+-- CONFIRM_DISENCHANT_ROLL is Retail-only; Classic clients reject it
 local ROLL_FRAME_EVENTS = {
-    "START_LOOT_ROLL", "CANCEL_LOOT_ROLL",
-    "CONFIRM_LOOT_ROLL", "CONFIRM_DISENCHANT_ROLL",
+    "START_LOOT_ROLL", "CANCEL_LOOT_ROLL", "CONFIRM_LOOT_ROLL",
 }
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    ROLL_FRAME_EVENTS[#ROLL_FRAME_EVENTS + 1] = "CONFIRM_DISENCHANT_ROLL"
+end
 
 local lootFrameHooked = false
 

--- a/DragonLoot_Options/DragonLoot_Options.toc
+++ b/DragonLoot_Options/DragonLoot_Options.toc
@@ -9,23 +9,23 @@
 ## LoadOnDemand: 1
 
 ## DragonWidgets embedded library
-Libs\DragonWidgets\DragonWidgets.lua
-Libs\DragonWidgets\LayoutConstants.lua
-Libs\DragonWidgets\Widgets\WidgetConstants.lua
-Libs\DragonWidgets\Widgets\Panel.lua
-Libs\DragonWidgets\Widgets\ScrollFrame.lua
-Libs\DragonWidgets\Widgets\TabGroup.lua
-Libs\DragonWidgets\Widgets\Header.lua
-Libs\DragonWidgets\Widgets\Description.lua
-Libs\DragonWidgets\Widgets\Section.lua
-Libs\DragonWidgets\Widgets\Toggle.lua
-Libs\DragonWidgets\Widgets\Slider.lua
-Libs\DragonWidgets\Widgets\Dropdown.lua
-Libs\DragonWidgets\Widgets\ColorPicker.lua
-Libs\DragonWidgets\Widgets\TextInput.lua
-Libs\DragonWidgets\Widgets\Button.lua
-Libs\DragonWidgets\Widgets\ItemSlot.lua
-Libs\DragonWidgets\Widgets\ItemList.lua
+Libs\DragonWidgets\DragonWidgets\DragonWidgets.lua
+Libs\DragonWidgets\DragonWidgets\LayoutConstants.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\WidgetConstants.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Panel.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\ScrollFrame.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\TabGroup.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Header.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Description.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Section.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Toggle.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Slider.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Dropdown.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\ColorPicker.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\TextInput.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Button.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\ItemSlot.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\ItemList.lua
 
 Core.lua
 Tabs\GeneralTab.lua


### PR DESCRIPTION
## Summary

Fixes two in-game errors reported after recent merges.

## Bug 1: DragonWidgets not loaded ([DragonLoot_Options])

**Error:** `[DragonLoot_Options] DragonWidgets is not loaded` + `attempt to index field 'DW' (a nil value)` in every tab file.

**Root cause:** The DragonWidgets submodule at `Libs/DragonWidgets/` contains only repo metadata at its root. The actual Lua files are one directory deeper at `Libs/DragonWidgets/DragonWidgets/`. The TOC was pointing to the wrong level.

**Fix:** Prefixed all 17 DragonWidgets file paths in `DragonLoot_Options.toc` with an extra `DragonWidgets\` segment to match the actual on-disk layout.

## Bug 2: CONFIRM_DISENCHANT_ROLL unknown event on Classic

**Error:** `UIParent:RegisterEvent(): Attempt to register unknown event "CONFIRM_DISENCHANT_ROLL"` on Classic clients (TBC Anniversary, MoP Classic).

**Root cause:** `ROLL_FRAME_EVENTS` in `Init.lua` was built unconditionally and included `CONFIRM_DISENCHANT_ROLL`, which is a Retail-only event. `RestoreBlizzardRollFrames` (called from `OnDisable`) iterated this table and attempted to register the unknown event on Classic clients.

**Fix:** `ROLL_FRAME_EVENTS` is now built with the three cross-version events as the base, and `CONFIRM_DISENCHANT_ROLL` is appended only when `WOW_PROJECT_ID == WOW_PROJECT_MAINLINE`. This matches the pattern already used by `RollListener_Classic.lua` which pcall-wraps the same event.

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- `luacheck` passes with 0 new warnings
- DragonWidgets loads correctly via the fixed TOC paths
- Classic clients no longer error on `OnDisable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client compatibility issue by preventing unsupported events from being registered on Classic clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->