### PR TITLE
fix: transmog button now occupies greed slot in roll button chain (#121)

### DIFF
--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -280,11 +280,8 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
             -(GetRollContentRightInset(iconSize, padding, borderSize)), 0)
         frame.passButton:SetPoint("TOP", frame, "TOP", 0, -(padding + borderSize))
 
-        -- Determine leftmost button
+        -- needButton is always the leftmost button (transmog occupies greed's slot to the right).
         local leftmostButton = frame.needButton
-        if frame.transmogButton and frame.transmogButton:IsShown() then
-            leftmostButton = frame.transmogButton
-        end
 
         if frame.bindText:IsShown() then
             -- bindText sits to the left of the buttons
@@ -687,7 +684,6 @@ local function CreateRollFrame(index)
         frame.transmogButton.icon:SetTexture("Interface\\ICONS\\INV_Enchant_Disenchant")
         frame.transmogButton:SetHighlightTexture("Interface\\ICONS\\INV_Enchant_Disenchant", "ADD")
     end
-    frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -GetButtonSpacing(), 0)
     frame.transmogButton:Hide()
 
     frame.frameIndex = index
@@ -773,6 +769,39 @@ local function BuildTestRollData(testEntry)
         reasonDisenchant = nil,
         duration = testEntry.duration,
     }
+end
+
+-------------------------------------------------------------------------------
+-- Re-anchor the roll button chain based on current greed/transmog visibility.
+-- When transmog is shown (greed's slot), the chain is:
+--   need <- transmog <- disenchant <- pass
+-- When greed is shown (normal), the chain is:
+--   need <- greed <- disenchant <- pass
+-------------------------------------------------------------------------------
+
+local function RebuildButtonChain(frame)
+    local btnSpacing = GetButtonSpacing()
+    -- disenchant always anchors off pass
+    frame.disenchantButton:ClearAllPoints()
+    frame.disenchantButton:SetPoint("RIGHT", frame.passButton, "LEFT", -btnSpacing, 0)
+
+    -- greed/transmog share the slot between disenchant and need
+    -- transmogButton is always created in CreateRollFrame; nil guard is unnecessary.
+    -- IsShown() (not IsVisible()) is intentional: parent frame may be hidden,
+    -- but we need to know whether transmog was set for this roll's data.
+    if frame.transmogButton:IsShown() then
+        -- transmog occupies greed's slot
+        frame.transmogButton:ClearAllPoints()
+        frame.transmogButton:SetPoint("RIGHT", frame.disenchantButton, "LEFT", -btnSpacing, 0)
+        frame.needButton:ClearAllPoints()
+        frame.needButton:SetPoint("RIGHT", frame.transmogButton, "LEFT", -btnSpacing, 0)
+    else
+        -- greed in its normal slot
+        frame.greedButton:ClearAllPoints()
+        frame.greedButton:SetPoint("RIGHT", frame.disenchantButton, "LEFT", -btnSpacing, 0)
+        frame.needButton:ClearAllPoints()
+        frame.needButton:SetPoint("RIGHT", frame.greedButton, "LEFT", -btnSpacing, 0)
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -880,17 +909,18 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     SetButtonState(frame.disenchantButton, data.canDisenchant, data.reasonDisenchant)
     SetButtonState(frame.passButton, true, nil)
 
-    if frame.transmogButton then
-        if data.canTransmog then
-            frame.transmogButton:Show()
-            SetButtonState(frame.transmogButton, true, nil)
-            -- Match Blizzard: Transmog replaces Greed
-            frame.greedButton:Hide()
-        else
-            frame.transmogButton:Hide()
-            frame.greedButton:Show()
-        end
+    -- Toggle transmog/greed visibility and rebuild the button chain accordingly.
+    -- transmogButton is always created; when canTransmog is true it occupies greed's slot.
+    if data.canTransmog then
+        frame.transmogButton:Show()
+        SetButtonState(frame.transmogButton, true, nil)
+        -- Match Blizzard: Transmog replaces Greed
+        frame.greedButton:Hide()
+    else
+        frame.transmogButton:Hide()
+        frame.greedButton:Show()
     end
+    RebuildButtonChain(frame)
 
     -- Mode-specific frame state
     if isTest then
@@ -1177,22 +1207,12 @@ function ns.RollFrame.ApplySettings()
             frame.disenchantButton:SetSize(btnSize, btnSize)
             frame.greedButton:SetSize(btnSize, btnSize)
             frame.needButton:SetSize(btnSize, btnSize)
-            if frame.transmogButton then
-                frame.transmogButton:SetSize(btnSize, btnSize)
-            end
+            frame.transmogButton:SetSize(btnSize, btnSize) -- always created in CreateRollFrame
 
-            -- Re-anchor button chain with current spacing
-            local btnSpacing = GetButtonSpacing()
-            frame.disenchantButton:ClearAllPoints()
-            frame.disenchantButton:SetPoint("RIGHT", frame.passButton, "LEFT", -btnSpacing, 0)
-            frame.greedButton:ClearAllPoints()
-            frame.greedButton:SetPoint("RIGHT", frame.disenchantButton, "LEFT", -btnSpacing, 0)
-            frame.needButton:ClearAllPoints()
-            frame.needButton:SetPoint("RIGHT", frame.greedButton, "LEFT", -btnSpacing, 0)
-            if frame.transmogButton then
-                frame.transmogButton:ClearAllPoints()
-                frame.transmogButton:SetPoint("RIGHT", frame.needButton, "LEFT", -btnSpacing, 0)
-            end
+            -- Re-anchor button chain based on current greed/transmog IsShown() state.
+            -- Safe on unrendered frames: greedButton defaults to shown,
+            -- transmogButton defaults to hidden, matching CreateRollFrame state.
+            RebuildButtonChain(frame)
 
             -- Adjust frame height based on icon size
             frame:SetHeight(CalculateFrameHeight(iconSize))


### PR DESCRIPTION
## Summary

When an item can be transmogged, the transmog button now occupies greed's slot in the button chain, matching Blizzard's `GroupLootFrame` behavior.

**Before:** `[transmog] [need] [gap] [disenchant] [pass]`
**After:** `[need] [transmog] [disenchant] [pass]`

## Changes

- **`RebuildButtonChain(frame)`** - new local helper that re-anchors the button chain based on current greed/transmog `IsShown()` state:
  - `canTransmog=true`: `need <- transmog <- disenchant <- pass`
  - `canTransmog=false`: `need <- greed <- disenchant <- pass`
- **`CreateRollFrame`** - removed static transmog `SetPoint`; chain is built dynamically by `RebuildButtonChain` instead
- **`RenderRollFrame`** - calls `RebuildButtonChain` after toggling transmog/greed visibility
- **`ApplySettings`** - replaced 12-line hardcoded chain re-anchor with a single `RebuildButtonChain(frame)` call
- **Consistency cleanup** - removed dead nil-guards on `transmogButton` in `ApplyTextLayoutOffsets` and `ApplySettings` (button is always created in `CreateRollFrame`)

## Testing

- [ ] Loot an item with `canTransmog=true` - transmog button appears in greed's slot, no gap
- [ ] Loot an item with `canTransmog=false` - greed button appears normally
- [ ] Open options and change button spacing while a transmog roll is active - chain stays correct
- [ ] Classic: greed/need/DE/pass layout unaffected (transmog button is created but never shown)

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transmog button visibility and positioning in roll frames to accurately reflect availability.
  * Improved button anchor chain recalibration when transmog settings change to ensure proper layout.
  * Enhanced settings application to correctly resize and reposition transmog buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->