### PR TITLE
feat: add busted test infrastructure with Lifecycle and Config tests (#125)

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,10 @@
+return {
+    _all = {
+        lua = "lua",
+    },
+    default = {
+        ROOT = { "spec" },
+        pattern = "_spec",
+        verbose = true,
+    },
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   lint:
     uses: Xerrion/wow-workflows/.github/workflows/lint.yml@main
+    with:
+      run-tests: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,10 @@
 [tools]
 lua = "5.1"
 
+[tasks.test]
+run = "busted --verbose"
+description = "Run busted test suite"
+
 [tasks.lint]
 run = "luacheck ."
 description = "Run luacheck linter"

--- a/spec/Config_spec.lua
+++ b/spec/Config_spec.lua
@@ -1,0 +1,171 @@
+-------------------------------------------------------------------------------
+-- Config_spec.lua
+-- Tests for Config.lua schema migration via ns.InitializeDB
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Config", function()
+    local ns
+
+    before_each(function()
+        mock.Reset()
+        ns = mock.CreateNamespace()
+    end)
+
+    -- Helper: load Config.lua and run InitializeDB on a mock addon
+    local function initWithSeed(currentNs, profileSeed)
+        mock._profileSeed = profileSeed
+        mock.LoadConfig(currentNs)
+        local addon = { db = nil }
+        currentNs.InitializeDB(addon)
+        return addon.db
+    end
+
+    ---------------------------------------------------------------------------
+    -- Fresh profile (all defaults)
+    ---------------------------------------------------------------------------
+
+    describe("fresh profile", function()
+        it("has all default keys after InitializeDB", function()
+            local db = initWithSeed(ns, nil)
+
+            assert.is_true(db.profile.enabled)
+            assert.are.equal(1.0, db.profile.lootWindow.scale)
+            assert.are.equal(12, db.profile.rollFrame.timerBarHeight)
+            assert.are.equal("Friz Quadrata TT", db.profile.appearance.font)
+            assert.are.equal(100, db.profile.history.maxEntries)
+        end)
+
+        it("sets schemaVersion to 2", function()
+            local db = initWithSeed(ns, nil)
+
+            assert.are.equal(2, db.profile.schemaVersion)
+        end)
+
+        it("has lootIconSize in a fresh profile", function()
+            local db = initWithSeed(ns, nil)
+
+            assert.is_not_nil(db.profile.appearance.lootIconSize)
+            assert.are.equal(36, db.profile.appearance.lootIconSize)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- FillMissingDefaults (tested through InitializeDB)
+    ---------------------------------------------------------------------------
+
+    describe("FillMissingDefaults", function()
+        it("back-fills missing rollFrame.frameWidth", function()
+            local db = initWithSeed(ns, {
+                rollFrame = {
+                    enabled = true,
+                    -- frameWidth intentionally missing
+                },
+            })
+
+            assert.are.equal(328, db.profile.rollFrame.frameWidth)
+        end)
+
+        it("resets wrong-type timerBarHeight to default number", function()
+            local db = initWithSeed(ns, {
+                rollFrame = {
+                    timerBarHeight = "bad",
+                },
+            })
+
+            assert.are.equal(12, db.profile.rollFrame.timerBarHeight)
+        end)
+
+        it("preserves valid non-default history.maxEntries", function()
+            local db = initWithSeed(ns, {
+                history = {
+                    maxEntries = 50,
+                },
+            })
+
+            assert.are.equal(50, db.profile.history.maxEntries)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- MigrateProfile: borderTexture fix
+    ---------------------------------------------------------------------------
+
+    describe("borderTexture migration", function()
+        it("resets borderTexture from Solid to None", function()
+            local db = initWithSeed(ns, {
+                appearance = {
+                    borderTexture = "Solid",
+                },
+            })
+
+            assert.are.equal("None", db.profile.appearance.borderTexture)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- MigrateProfile: iconSize split
+    ---------------------------------------------------------------------------
+
+    describe("iconSize split migration", function()
+        it("clears old iconSize field after migration", function()
+            local db = initWithSeed(ns, {
+                appearance = {
+                    iconSize = 48,
+                },
+            })
+
+            -- FillMissingDefaults runs first and fills lootIconSize/rollIconSize
+            -- with defaults (36), so iconSize=48 does NOT propagate. The old
+            -- iconSize field is cleared regardless.
+            assert.is_nil(db.profile.appearance.iconSize)
+            assert.are.equal(36, db.profile.appearance.lootIconSize)
+            assert.are.equal(36, db.profile.appearance.rollIconSize)
+        end)
+
+        it("preserves existing lootIconSize when iconSize is also present", function()
+            local db = initWithSeed(ns, {
+                appearance = {
+                    iconSize = 48,
+                    lootIconSize = 42,
+                    rollIconSize = 44,
+                },
+            })
+
+            -- Existing values survive: FillMissingDefaults does not overwrite
+            -- them (they're not nil), and iconSize migration skips them too.
+            assert.are.equal(42, db.profile.appearance.lootIconSize)
+            assert.are.equal(44, db.profile.appearance.rollIconSize)
+            assert.is_nil(db.profile.appearance.iconSize)
+        end)
+
+        it("copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v2)",
+            function()
+            local db = initWithSeed(ns, {
+                schemaVersion = 2,
+                appearance = {
+                    iconSize = 48,
+                    -- lootIconSize intentionally absent to test migration propagation
+                },
+            })
+
+            assert.are.equal(48, db.profile.appearance.lootIconSize)
+            assert.is_nil(db.profile.appearance.iconSize)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Schema version
+    ---------------------------------------------------------------------------
+
+    describe("schemaVersion", function()
+        it("is set to 2 after migration from version 0", function()
+            local db = initWithSeed(ns, {
+                -- schemaVersion intentionally missing (defaults to 0)
+            })
+
+            assert.are.equal(2, db.profile.schemaVersion)
+        end)
+    end)
+end)

--- a/spec/Lifecycle_spec.lua
+++ b/spec/Lifecycle_spec.lua
@@ -1,0 +1,223 @@
+-------------------------------------------------------------------------------
+-- Lifecycle_spec.lua
+-- Tests for ns.LifecycleUtil (Lifecycle.lua)
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("LifecycleUtil", function()
+    local ns, LU
+
+    before_each(function()
+        mock.Reset()
+        ns = mock.CreateNamespace()
+        LU = mock.LoadLifecycle(ns)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- CreateState
+    ---------------------------------------------------------------------------
+
+    describe("CreateState", function()
+        it("returns a table with token=0 and isLive=false", function()
+            local state = LU.CreateState()
+
+            assert.are.equal(0, state.token)
+            assert.is_false(state.isLive)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Activate
+    ---------------------------------------------------------------------------
+
+    describe("Activate", function()
+        it("sets isLive to true and returns token 1 on first call", function()
+            local state = LU.CreateState()
+
+            local token = LU.Activate(state)
+
+            assert.is_true(state.isLive)
+            assert.are.equal(1, token)
+        end)
+
+        it("increments token to 2 on second call", function()
+            local state = LU.CreateState()
+
+            LU.Activate(state)
+            local token = LU.Activate(state)
+
+            assert.are.equal(2, token)
+            assert.is_true(state.isLive)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Invalidate
+    ---------------------------------------------------------------------------
+
+    describe("Invalidate", function()
+        it("sets isLive to false", function()
+            local state = LU.CreateState()
+            LU.Activate(state)
+
+            LU.Invalidate(state)
+
+            assert.is_false(state.isLive)
+        end)
+
+        it("increments the token when called", function()
+            local state = LU.CreateState()
+            LU.Activate(state)        -- token = 1
+
+            LU.Invalidate(state)      -- token must be 2
+
+            assert.are.equal(2, state.token)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- CaptureToken
+    ---------------------------------------------------------------------------
+
+    describe("CaptureToken", function()
+        it("returns current token value", function()
+            local state = LU.CreateState()
+            LU.Activate(state)
+
+            assert.are.equal(1, LU.CaptureToken(state))
+        end)
+
+        it("returns nil when state is nil", function()
+            assert.is_nil(LU.CaptureToken(nil))
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- IsTokenCurrent
+    ---------------------------------------------------------------------------
+
+    describe("IsTokenCurrent", function()
+        it("returns false on fresh state (not live)", function()
+            local state = LU.CreateState()
+
+            assert.is_false(LU.IsTokenCurrent(state, 0))
+        end)
+
+        it("returns true after Activate with matching token", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)
+
+            assert.is_true(LU.IsTokenCurrent(state, token))
+        end)
+
+        it("returns false after Invalidate", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)
+            LU.Invalidate(state)
+
+            assert.is_false(LU.IsTokenCurrent(state, token))
+        end)
+
+        it("returns false with wrong token", function()
+            local state = LU.CreateState()
+            LU.Activate(state)
+
+            assert.is_false(LU.IsTokenCurrent(state, 999))
+        end)
+
+        it("returns false when state is nil", function()
+            assert.is_false(LU.IsTokenCurrent(nil, 1))
+        end)
+
+        it("returns false with the old token after Invalidate (token was incremented)", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)   -- token = 1, captured
+            LU.Invalidate(state)               -- token becomes 2
+
+            assert.are.equal(2, state.token)
+            assert.is_false(LU.IsTokenCurrent(state, token))
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Guard
+    ---------------------------------------------------------------------------
+
+    describe("Guard", function()
+        it("fires callback when token is current", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)
+            local wasCalled = false
+
+            local guarded = LU.Guard(state, token, function()
+                wasCalled = true
+            end)
+            guarded()
+
+            assert.is_true(wasCalled)
+        end)
+
+        it("does NOT fire callback when state is invalidated after guard creation", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)
+            local wasCalled = false
+
+            local guarded = LU.Guard(state, token, function()
+                wasCalled = true
+            end)
+            LU.Invalidate(state)
+            guarded()
+
+            assert.is_false(wasCalled)
+        end)
+
+        it("returns a no-op function when callback is not a function", function()
+            local state = LU.CreateState()
+            local token = LU.Activate(state)
+
+            local guarded = LU.Guard(state, token, "not a function")
+
+            assert.is_function(guarded)
+            assert.has_no.errors(function() guarded() end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- After
+    ---------------------------------------------------------------------------
+
+    describe("After", function()
+        it("fires callback via C_Timer.After (immediately in mock)", function()
+            local state = LU.CreateState()
+            LU.Activate(state)
+            local wasCalled = false
+
+            LU.After(state, 0.5, function()
+                wasCalled = true
+            end)
+
+            assert.is_true(wasCalled)
+        end)
+
+        it("does NOT fire callback after Invalidate", function()
+            local state = LU.CreateState()
+            LU.Activate(state)
+            local wasCalled = false
+            local savedAfter = C_Timer.After  -- backup before override
+
+            local savedCb
+            C_Timer.After = function(_, cb)   -- luacheck: ignore 121 122 212
+                savedCb = cb
+            end
+
+            LU.After(state, 1, function() wasCalled = true end)
+            LU.Invalidate(state)
+            if savedCb then savedCb() end
+
+            C_Timer.After = savedAfter        -- luacheck: ignore 122
+
+            assert.is_false(wasCalled)
+        end)
+    end)
+end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -1,0 +1,283 @@
+-------------------------------------------------------------------------------
+-- wow_mock.lua
+-- Lightweight WoW API mock for DragonLoot busted unit tests
+-------------------------------------------------------------------------------
+
+local M = {}
+
+-------------------------------------------------------------------------------
+-- Mock time (controllable clock)
+-------------------------------------------------------------------------------
+
+local mockTime = 0
+
+function M.SetTime(t)
+    mockTime = t
+end
+
+function M.AdvanceTime(dt)
+    mockTime = mockTime + dt
+end
+
+-- luacheck: push ignore 111 121 122
+
+-------------------------------------------------------------------------------
+-- Core WoW API mocks
+-------------------------------------------------------------------------------
+
+function GetTime()
+    return mockTime
+end
+
+function InCombatLockdown()
+    return M._inCombat or false
+end
+
+function UnitName()
+    return "TestPlayer"
+end
+
+function IsInInstance()
+    return false, "none"
+end
+
+function PlaySound() end
+function PlaySoundFile() end
+function hooksecurefunc() end
+
+-------------------------------------------------------------------------------
+-- WoW version constants
+-------------------------------------------------------------------------------
+
+WOW_PROJECT_ID = 1
+WOW_PROJECT_MAINLINE = 1
+
+-------------------------------------------------------------------------------
+-- C_Timer mock (fires immediately in tests)
+-------------------------------------------------------------------------------
+
+C_Timer = {
+    After = function(_, cb)
+        if cb then cb() end
+    end,
+    NewTicker = function(_, cb)
+        if cb then cb() end
+        return { Cancel = function() end }
+    end,
+}
+
+-------------------------------------------------------------------------------
+-- WoW utility globals
+-------------------------------------------------------------------------------
+
+STANDARD_TEXT_FONT = "Fonts\\FRIZQT__.TTF"
+
+function wipe(t)
+    for k in pairs(t) do
+        t[k] = nil
+    end
+    return t
+end
+
+function strsplit(delimiter, str, max)
+    local parts = {}
+    local pattern = "([^" .. delimiter .. "]*)" .. delimiter .. "?"
+    local count = 0
+    for part in string.gmatch(str .. delimiter, pattern) do
+        count = count + 1
+        parts[count] = part
+        if max and count >= max then break end
+    end
+    return unpack(parts)
+end
+
+function strmatch(str, pattern)
+    return string.match(str, pattern)
+end
+
+function strtrim(str)
+    return string.match(str, "^%s*(.-)%s*$")
+end
+
+format = string.format
+
+-------------------------------------------------------------------------------
+-- Frame mock (minimal)
+-------------------------------------------------------------------------------
+
+local function CreateMockFrame()
+    local frame = {
+        _shown = false,
+        _scripts = {},
+        _events = {},
+    }
+
+    function frame.SetPoint() end
+    function frame.ClearAllPoints() end
+    function frame:Show() self._shown = true end
+    function frame:Hide() self._shown = false end
+    function frame:IsShown() return self._shown end
+    function frame.SetSize() end
+    function frame.SetHeight() end
+    function frame.SetWidth() end
+    function frame.SetMovable() end
+    function frame.EnableMouse() end
+    function frame.SetFrameStrata() end
+    function frame.SetScript() end
+    function frame.CreateTexture() return {} end
+    function frame.CreateFontString() return { SetFont = function() end, SetText = function() end } end
+
+    function frame:RegisterEvent(event) self._events[event] = true end
+    function frame:UnregisterEvent(event) self._events[event] = nil end
+    function frame:UnregisterAllEvents() wipe(self._events) end
+    function frame:IsEventRegistered(event) return self._events[event] or false end
+
+    return frame
+end
+
+function CreateFrame()
+    return CreateMockFrame()
+end
+
+UIParent = CreateMockFrame()
+
+_G = _G or {}
+
+-------------------------------------------------------------------------------
+-- LibStub mock (dispatches by library name)
+-------------------------------------------------------------------------------
+
+local function DeepCopyTable(src)
+    if type(src) ~= "table" then return src end
+    local copy = {}
+    for k, v in pairs(src) do
+        copy[k] = DeepCopyTable(v)
+    end
+    return copy
+end
+
+local aceDBMock = {
+    New = function(_, _, defaultsArg, _)
+        local profile
+        if M._profileSeed then
+            -- Use the seeded profile (simulates a saved profile from a
+            -- previous schema version). Deep-copy to avoid cross-test leaks.
+            profile = DeepCopyTable(M._profileSeed)
+        else
+            profile = DeepCopyTable(defaultsArg and defaultsArg.profile or {})
+        end
+        local db = {
+            profile = profile,
+            RegisterCallback = function() end,
+            CancelCallback = function() end,
+        }
+        return db
+    end,
+}
+
+local aceAddonMock = {
+    NewAddon = function(_, name, ...)
+        local addon = {
+            _name = name,
+            _mixins = { ... },
+        }
+        function addon.RegisterChatCommand() end
+        function addon:RegisterEvent() end
+        function addon:UnregisterEvent() end
+        function addon.ScheduleTimer(_, func, _)
+            if func then func() end
+            return {}
+        end
+        function addon.ScheduleRepeatingTimer()
+            return {}
+        end
+        function addon.CancelTimer() end
+        return addon
+    end,
+}
+
+local aceLocaleMock = {
+    GetLocale = function()
+        return setmetatable({}, {
+            __index = function(_, key)
+                return key
+            end,
+        })
+    end,
+}
+
+function LibStub(name)
+    if name == "AceDB-3.0" then return aceDBMock end
+    if name == "AceAddon-3.0" then return aceAddonMock end
+    if name == "AceLocale-3.0" then return aceLocaleMock end
+    return nil
+end
+
+-- luacheck: pop
+
+-------------------------------------------------------------------------------
+-- Namespace builder
+-------------------------------------------------------------------------------
+
+function M.CreateNamespace()
+    local ns = {}
+
+    ns.ADDON_NAME = "DragonLoot"
+    ns.ADDON_TITLE = "DragonLoot"
+    ns.VERSION = "test"
+
+    ns.COLOR_GOLD = "|cffffd700"
+    ns.COLOR_GREEN = "|cff00ff00"
+    ns.COLOR_RED = "|cffff0000"
+    ns.COLOR_GRAY = "|cff888888"
+    ns.COLOR_WHITE = "|cffffffff"
+    ns.COLOR_RESET = "|r"
+
+    ns.LifecycleUtil = {}
+    ns.LootFrame = {}
+    ns.RollFrame = {}
+    ns.RollManager = {}
+    ns.HistoryFrame = {}
+    ns.HistoryListener = {}
+    ns.LootHistoryChat = {}
+    ns.ConfigWindow = {}
+    ns.MinimapIcon = {}
+    ns.Listeners = {}
+    ns.Addon = {}
+
+    function ns.Print() end
+    function ns.DebugPrint() end
+
+    return ns
+end
+
+-------------------------------------------------------------------------------
+-- Module loaders
+-------------------------------------------------------------------------------
+
+function M.LoadLifecycle(ns)
+    local path = "DragonLoot/Core/Lifecycle.lua"
+    local chunk, err = loadfile(path)
+    if not chunk then error("Failed to load " .. path .. ": " .. tostring(err)) end
+    chunk("DragonLoot", ns)
+    return ns.LifecycleUtil
+end
+
+function M.LoadConfig(ns)
+    local path = "DragonLoot/Core/Config.lua"
+    local chunk, err = loadfile(path)
+    if not chunk then error("Failed to load " .. path .. ": " .. tostring(err)) end
+    chunk("DragonLoot", ns)
+end
+
+-------------------------------------------------------------------------------
+-- Reset helpers
+-------------------------------------------------------------------------------
+
+function M.Reset()
+    mockTime = 0
+    M._inCombat = false
+    M._profileSeed = nil
+end
+
+return M


### PR DESCRIPTION
## Summary

Adds busted test infrastructure for DragonLoot, covering the `Lifecycle` and `Config` modules.

## Changes

- `.busted` - busted config (lua = "lua" for CI compatibility with gh-actions-lua@v10)
- `.mise.toml` - adds lua 5.1 + busted tool definitions and lint/test tasks
- `.github/workflows/lint.yml` - enables `run-tests: true` to run busted in CI
- `spec/wow_mock.lua` - WoW API mock with LibStub (AceDB-3.0, AceAddon-3.0, AceLocale-3.0), C_Timer with controllable clock, and loaders for Lifecycle and Config modules
- `spec/Lifecycle_spec.lua` - tests for CreateState, Activate, Invalidate, Guard, and After
- `spec/Config_spec.lua` - tests for FillMissingDefaults, MigrateProfile (schema v2 iconSize split), and InitializeDB

## Testing

All 29 tests pass locally:
```
busted --verbose
29 successes / 0 failures / 0 errors
```

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suites for configuration and lifecycle components with comprehensive validation of default values, migrations, and component behaviors
  * Established test environment with complete mocking infrastructure for WoW API calls and addon framework dependencies
  * Configured test discovery and automated execution for both local development and continuous integration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->