### PR TITLE
chore: add stylua formatting and justfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,24 @@
 [submodule "DragonLoot/Libs/Ace3"]
 	path = DragonLoot/Libs/Ace3
 	url = https://github.com/WoWUIDev/Ace3.git
+	ignore = dirty
 [submodule "DragonLoot/Libs/LibAnimate"]
 	path = DragonLoot/Libs/LibAnimate
 	url = https://github.com/Xerrion/LibAnimate.git
+	ignore = dirty
 [submodule "DragonLoot/Libs/LibDataBroker-1.1"]
 	path = DragonLoot/Libs/LibDataBroker-1.1
 	url = https://github.com/tekkub/libdatabroker-1-1.git
+	ignore = dirty
 [submodule "DragonLoot/Libs/LibDBIcon-1.0"]
 	path = DragonLoot/Libs/LibDBIcon-1.0
 	url = https://github.com/kaldown/LibDBIcon-1.0.git
+	ignore = dirty
 [submodule "DragonLoot/Libs/LibSharedMedia-3.0"]
 	path = DragonLoot/Libs/LibSharedMedia-3.0
 	url = https://github.com/wowace-clone/LibSharedMedia-3.0.git
+	ignore = dirty
 [submodule "DragonLoot_Options/Libs/DragonWidgets"]
 	path = DragonLoot_Options/Libs/DragonWidgets
 	url = https://github.com/Xerrion/DragonWidgets
+	ignore = dirty

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,9 @@
 [tools]
 lua = "5.1"
+stylua = "latest"
+
+[env]
+_.path = ["{{config_root}}/.luarocks/bin", "{{env.HOME}}/.local/share/mise/installs/lua/5.1/luarocks/bin"]
 
 [tasks.test]
 run = "busted --verbose"

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,50 @@ DragonLoot embeds Ace3 via `Libs/embeds.xml`. The full Ace3 library set is avail
 
 ---
 
+## Development Commands
+
+Development tasks are managed via [just](https://github.com/casey/just) (justfile) and [mise](https://mise.jdx.dev/) (.mise.toml).
+
+### Prerequisites
+
+```sh
+# Install mise (if not already installed)
+# See https://mise.jdx.dev/getting-started.html
+
+# Install all project tools (Lua 5.1, StyLua)
+mise install
+```
+
+### Just Recipes
+
+| Command | Description |
+|---------|-------------|
+| `just` | List all available recipes |
+| `just test` | Run busted test suite |
+| `just lint` | Run luacheck linter |
+| `just fmt` | Format Lua files with StyLua |
+| `just fmt-check` | Check formatting without modifying files |
+| `just check` | Run lint + test |
+
+### Mise Tasks
+
+| Command | Description |
+|---------|-------------|
+| `mise run test` | Run `busted --verbose` |
+| `mise run lint` | Run `luacheck .` |
+
+### Code Style
+
+Enforced by `.stylua.toml`:
+
+- 120-character column width
+- 4-space indentation (no tabs)
+- Double quotes preferred
+- Unix line endings
+- Always parenthesized function calls
+
+---
+
 ## Known Gotchas
 
 1. **GetItemInfo may return nil** on first call if item not cached - handle with retry timers

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -68,7 +68,7 @@ local defaults = {
             autoShow = false,
             lock = false,
             trackDirectLoot = true,
-            minQuality = 2,  -- Uncommon
+            minQuality = 2, -- Uncommon
             entrySpacing = 2,
             contentPadding = 6,
             showRollDetails = true,
@@ -117,11 +117,10 @@ local defaults = {
 
         autoLoot = {
             enabled = false,
-            minQuality = 4,  -- Epic
-            whitelist = {},   -- { [itemID] = true }
-            blacklist = {},   -- { [itemID] = true }
+            minQuality = 4, -- Epic
+            whitelist = {}, -- { [itemID] = true }
+            blacklist = {}, -- { [itemID] = true }
         },
-
     },
 }
 
@@ -132,7 +131,9 @@ local defaults = {
 local CURRENT_SCHEMA = 2
 
 local function DeepCopyValue(value)
-    if type(value) ~= "table" then return value end
+    if type(value) ~= "table" then
+        return value
+    end
     local copy = {}
     for k, v in pairs(value) do
         copy[k] = DeepCopyValue(v)
@@ -218,9 +219,15 @@ end
 -------------------------------------------------------------------------------
 
 local function NotifyAppearanceChange()
-    if ns.LootFrame and ns.LootFrame.ApplySettings then ns.LootFrame.ApplySettings() end
-    if ns.RollManager and ns.RollManager.ApplySettings then ns.RollManager.ApplySettings() end
-    if ns.HistoryFrame and ns.HistoryFrame.ApplySettings then ns.HistoryFrame.ApplySettings() end
+    if ns.LootFrame and ns.LootFrame.ApplySettings then
+        ns.LootFrame.ApplySettings()
+    end
+    if ns.RollManager and ns.RollManager.ApplySettings then
+        ns.RollManager.ApplySettings()
+    end
+    if ns.HistoryFrame and ns.HistoryFrame.ApplySettings then
+        ns.HistoryFrame.ApplySettings()
+    end
 end
 
 -------------------------------------------------------------------------------

--- a/DragonLoot/Core/ConfigWindow.lua
+++ b/DragonLoot/Core/ConfigWindow.lua
@@ -27,7 +27,9 @@ local function IsOptionsLoaded()
 end
 
 local function LoadOptions()
-    if IsOptionsLoaded() then return true end
+    if IsOptionsLoaded() then
+        return true
+    end
 
     if C_AddOns and C_AddOns.LoadAddOn then
         C_AddOns.LoadAddOn("DragonLoot_Options")

--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -108,7 +108,9 @@ end
 -- Events the default group roll frames listen for
 -- CONFIRM_DISENCHANT_ROLL is Retail-only; Classic clients reject it
 local ROLL_FRAME_EVENTS = {
-    "START_LOOT_ROLL", "CANCEL_LOOT_ROLL", "CONFIRM_LOOT_ROLL",
+    "START_LOOT_ROLL",
+    "CANCEL_LOOT_ROLL",
+    "CONFIRM_LOOT_ROLL",
 }
 if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
     ROLL_FRAME_EVENTS[#ROLL_FRAME_EVENTS + 1] = "CONFIRM_DISENCHANT_ROLL"
@@ -122,8 +124,12 @@ local lootFrameHooked = false
 -- and shows LootFrame before our ADDON_LOADED watcher fires.
 -- On Classic, LootFrame is part of the base UI and no force-load is needed.
 local function EnsureBlizzardLootFrameLoaded()
-    if LootFrame then return end
-    if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+    if LootFrame then
+        return
+    end
+    if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then
+        return
+    end
     if C_AddOns and C_AddOns.LoadAddOn then
         C_AddOns.LoadAddOn("Blizzard_LootUI")
     elseif LoadAddOn then
@@ -136,7 +142,9 @@ end
 
 local function SuppressBlizzardLootFrame()
     EnsureBlizzardLootFrameLoaded()
-    if not LootFrame then return end
+    if not LootFrame then
+        return
+    end
     LootFrame:UnregisterAllEvents()
     LootFrame:Hide()
 
@@ -180,7 +188,9 @@ local function SuppressBlizzardRollFrames()
 end
 
 local function RestoreBlizzardLootFrame()
-    if not LootFrame then return end
+    if not LootFrame then
+        return
+    end
     -- Only restore the base events all versions register at load time.
     -- Dynamic events (LOOT_SLOT_CLEARED, LOOT_SLOT_CHANGED) are re-registered
     -- by Blizzard's own OnShow handler when the frame next shows.
@@ -253,7 +263,9 @@ end
 
 function Addon:OnEnable()
     local db = self.db and self.db.profile
-    if not db or not db.enabled then return end
+    if not db or not db.enabled then
+        return
+    end
 
     -- Suppress Blizzard frames when our replacement is enabled
     if db.lootWindow and db.lootWindow.enabled then

--- a/DragonLoot/Core/Lifecycle.lua
+++ b/DragonLoot/Core/Lifecycle.lua
@@ -41,30 +41,37 @@ function LifecycleUtil.Invalidate(state)
 end
 
 function LifecycleUtil.CaptureToken(state)
-    if not state then return nil end
+    if not state then
+        return nil
+    end
     return state.token
 end
 
 function LifecycleUtil.IsTokenCurrent(state, token)
-    if not state then return false end
+    if not state then
+        return false
+    end
     return state.isLive and state.token == token
 end
 
 function LifecycleUtil.Guard(state, token, callback)
     if type(callback) ~= "function" then
-        return function()
-        end
+        return function() end
     end
 
     return function(...)
-        if not LifecycleUtil.IsTokenCurrent(state, token) then return end
+        if not LifecycleUtil.IsTokenCurrent(state, token) then
+            return
+        end
         callback(...)
     end
 end
 
 function LifecycleUtil.After(state, delay, callback)
     local token = LifecycleUtil.CaptureToken(state)
-    if token == nil then return nil end
+    if token == nil then
+        return nil
+    end
 
     C_Timer.After(delay, LifecycleUtil.Guard(state, token, callback))
     return token

--- a/DragonLoot/Core/MinimapIcon.lua
+++ b/DragonLoot/Core/MinimapIcon.lua
@@ -38,16 +38,11 @@ local function OnMinimapClick(_, button)
 end
 
 local function OnMinimapTooltipShow(tooltip)
-    tooltip:AddDoubleLine(
-        "DragonLoot",
-        ns.VERSION or "",
-        1, 0.82, 0, 0.6, 0.6, 0.6
-    )
+    tooltip:AddDoubleLine("DragonLoot", ns.VERSION or "", 1, 0.82, 0, 0.6, 0.6, 0.6)
     tooltip:AddLine(" ")
 
     local db = ns.Addon.db.profile
-    local status = db.enabled
-        and (ns.COLOR_GREEN .. L["Enabled"] .. ns.COLOR_RESET)
+    local status = db.enabled and (ns.COLOR_GREEN .. L["Enabled"] .. ns.COLOR_RESET)
         or (ns.COLOR_RED .. L["Disabled"] .. ns.COLOR_RESET)
     tooltip:AddLine(L["Status:"] .. " " .. status)
     tooltip:AddLine(" ")
@@ -82,7 +77,9 @@ end
 
 function ns.MinimapIcon.Toggle()
     local LDBIcon = LibStub("LibDBIcon-1.0", true)
-    if not LDBIcon then return end
+    if not LDBIcon then
+        return
+    end
 
     local db = ns.Addon.db.profile.minimap
     if db.hide then
@@ -96,7 +93,9 @@ end
 
 function ns.MinimapIcon.Refresh()
     local LDBIcon = LibStub("LibDBIcon-1.0", true)
-    if not LDBIcon then return end
+    if not LDBIcon then
+        return
+    end
 
     LDBIcon:Refresh("DragonLoot", ns.Addon.db.profile.minimap)
 end

--- a/DragonLoot/Core/SlashCommands.lua
+++ b/DragonLoot/Core/SlashCommands.lua
@@ -22,19 +22,19 @@ local L = ns.L
 -------------------------------------------------------------------------------
 
 local HELP_ENTRIES = {
-    { "",             L["Toggle addon on/off"] },
-    { " config",      L["Open settings panel"] },
-    { " minimap",     L["Toggle minimap icon"] },
-    { " enable",      L["Enable addon"] },
-    { " disable",     L["Disable addon"] },
-    { " reset",       L["Reset loot frame position"] },
-    { " test",        L["Show test loot"] },
-    { " testroll",    L["Show test roll frames"] },
+    { "", L["Toggle addon on/off"] },
+    { " config", L["Open settings panel"] },
+    { " minimap", L["Toggle minimap icon"] },
+    { " enable", L["Enable addon"] },
+    { " disable", L["Disable addon"] },
+    { " reset", L["Reset loot frame position"] },
+    { " test", L["Show test loot"] },
+    { " testroll", L["Show test roll frames"] },
     { " testroll loop", L["Start continuous test roll spawning"] },
     { " testroll stop", L["Stop continuous test roll spawning"] },
-    { " history",     L["Toggle loot history"] },
-    { " status",      L["Show current settings"] },
-    { " help",        L["Show this help"] },
+    { " history", L["Toggle loot history"] },
+    { " status", L["Show current settings"] },
+    { " help", L["Show this help"] },
 }
 
 local function PrintHelp()
@@ -53,8 +53,7 @@ local function PrintStatus()
 
     print(ns.COLOR_GOLD .. L["--- DragonLoot Status ---"] .. ns.COLOR_RESET)
 
-    local enabledStr = db.enabled
-        and (ns.COLOR_GREEN .. L["Yes"] .. ns.COLOR_RESET)
+    local enabledStr = db.enabled and (ns.COLOR_GREEN .. L["Yes"] .. ns.COLOR_RESET)
         or (ns.COLOR_RED .. L["No"] .. ns.COLOR_RESET)
     print("  " .. L["Enabled:"] .. " " .. enabledStr)
 
@@ -93,20 +92,16 @@ function ns.HandleSlashCommand(input)
 
     if cmd == "" then
         PrintHelp()
-
     elseif cmd == "config" or cmd == "options" or cmd == "settings" then
         if ns.ToggleConfigWindow then
             ns.ToggleConfigWindow()
         end
-
     elseif cmd == "minimap" then
         if ns.MinimapIcon.Toggle then
             ns.MinimapIcon.Toggle()
         end
-
     elseif cmd == "toggle" then
         ToggleAddon()
-
     elseif cmd == "enable" then
         local db = ns.Addon.db.profile
         if not db.enabled then
@@ -114,7 +109,6 @@ function ns.HandleSlashCommand(input)
             ns.Addon:OnEnable()
         end
         ns.Print(L["Addon enabled"])
-
     elseif cmd == "disable" then
         local db = ns.Addon.db.profile
         if db.enabled then
@@ -122,7 +116,6 @@ function ns.HandleSlashCommand(input)
             ns.Addon:OnDisable()
         end
         ns.Print(L["Addon disabled"])
-
     elseif cmd == "reset" then
         if ns.LootFrame.ResetAnchor then
             ns.LootFrame.ResetAnchor()
@@ -130,48 +123,40 @@ function ns.HandleSlashCommand(input)
         else
             ns.Print(L["Loot frame not yet available."])
         end
-
     elseif cmd == "test" then
         if ns.LootFrame.ShowTestLoot then
             ns.LootFrame.ShowTestLoot()
         else
             ns.Print(L["Test loot not yet available."])
         end
-
     elseif cmd == "testroll loop" then
         if ns.RollFrame.ShowTestRollLoop then
             ns.RollFrame.ShowTestRollLoop()
         else
             ns.Print(L["Test roll not yet available."])
         end
-
     elseif cmd == "testroll stop" then
         if ns.RollFrame.StopTestRollLoop then
             ns.RollFrame.StopTestRollLoop()
         else
             ns.Print(L["Test roll not yet available."])
         end
-
     elseif cmd == "testroll" then
         if ns.RollFrame.ShowTestRoll then
             ns.RollFrame.ShowTestRoll()
         else
             ns.Print(L["Test roll not yet available."])
         end
-
     elseif cmd == "history" then
         if ns.HistoryFrame.Toggle then
             ns.HistoryFrame.Toggle()
         else
             ns.Print(L["Loot history not yet available."])
         end
-
     elseif cmd == "status" then
         PrintStatus()
-
     elseif cmd == "help" or cmd == "?" then
         PrintHelp()
-
     else
         ns.Print(L["Unknown command:"] .. " " .. ns.COLOR_WHITE .. cmd .. ns.COLOR_RESET)
         PrintHelp()

--- a/DragonLoot/Display/DisplayUtils.lua
+++ b/DragonLoot/Display/DisplayUtils.lua
@@ -61,9 +61,13 @@ end
 -------------------------------------------------------------------------------
 
 function DisplayUtils.ApplyFontShadow(fontString, db)
-    if not fontString or not fontString.SetShadowOffset then return end
+    if not fontString or not fontString.SetShadowOffset then
+        return
+    end
     local appearance = db and db.profile and db.profile.appearance
-    if not appearance then return end
+    if not appearance then
+        return
+    end
     if appearance.fontShadow then
         fontString:SetShadowOffset(1, -1)
         fontString:SetShadowColor(0, 0, 0, 1)
@@ -96,15 +100,15 @@ end
 
 function DisplayUtils.ApplyBackdrop(frame, db)
     local appearance = db.profile.appearance
-    if not appearance then return end
+    if not appearance then
+        return
+    end
 
     frame:SetBackdrop(DisplayUtils.GetBackdropSettings(db))
 
     local bg = appearance.backgroundColor
     if bg then
-        frame:SetBackdropColor(
-            bg.r or 0.05, bg.g or 0.05, bg.b or 0.05,
-            appearance.backgroundAlpha or 0.9)
+        frame:SetBackdropColor(bg.r or 0.05, bg.g or 0.05, bg.b or 0.05, appearance.backgroundAlpha or 0.9)
     else
         frame:SetBackdropColor(0.05, 0.05, 0.05, appearance.backgroundAlpha or 0.9)
     end

--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -25,7 +25,6 @@ local tostring = tostring
 local L = ns.L
 local DU = ns.DisplayUtils
 
-
 -------------------------------------------------------------------------------
 -- Constants
 -------------------------------------------------------------------------------
@@ -111,17 +110,31 @@ local function ApplyLayoutOffsets(frame)
     -- Scroll frame and scrollbar insets
     if scrollFrame then
         scrollFrame:ClearAllPoints()
-        scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT",
-            padding + borderSize, -(TITLE_BAR_HEIGHT + padding + borderSize))
-        scrollFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-            -(padding + SCROLLBAR_WIDTH + SCROLLBAR_GAP + borderSize), padding + borderSize)
+        scrollFrame:SetPoint(
+            "TOPLEFT",
+            frame,
+            "TOPLEFT",
+            padding + borderSize,
+            -(TITLE_BAR_HEIGHT + padding + borderSize)
+        )
+        scrollFrame:SetPoint(
+            "BOTTOMRIGHT",
+            frame,
+            "BOTTOMRIGHT",
+            -(padding + SCROLLBAR_WIDTH + SCROLLBAR_GAP + borderSize),
+            padding + borderSize
+        )
     end
     if scrollBar then
         scrollBar:ClearAllPoints()
-        scrollBar:SetPoint("TOPRIGHT", frame, "TOPRIGHT",
-            -(padding + borderSize), -(TITLE_BAR_HEIGHT + padding + borderSize))
-        scrollBar:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-            -(padding + borderSize), padding + borderSize)
+        scrollBar:SetPoint(
+            "TOPRIGHT",
+            frame,
+            "TOPRIGHT",
+            -(padding + borderSize),
+            -(TITLE_BAR_HEIGHT + padding + borderSize)
+        )
+        scrollBar:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -(padding + borderSize), padding + borderSize)
     end
 end
 
@@ -150,9 +163,13 @@ end
 -------------------------------------------------------------------------------
 
 local function FormatTimeAgo(timestamp)
-    if not timestamp then return "" end
+    if not timestamp then
+        return ""
+    end
     local elapsed = GetTime() - timestamp
-    if elapsed < 0 then elapsed = 0 end
+    if elapsed < 0 then
+        elapsed = 0
+    end
 
     if elapsed < 60 then
         return string_format(L["%ds ago"], math_floor(elapsed))
@@ -321,7 +338,9 @@ local function AcquireEntry()
 end
 
 local function ReleaseEntry(entry)
-    if entry._isPooled then return end
+    if entry._isPooled then
+        return
+    end
     entry._isPooled = true
     ReleaseEntryDetails(entry)
     entry:Hide()
@@ -335,7 +354,9 @@ local function ReleaseEntry(entry)
     entry.winnerName:SetText("")
     entry.rollInfo:SetText("")
     entry.timeText:SetText("")
-    if entry.expandIndicator then entry.expandIndicator:Hide() end
+    if entry.expandIndicator then
+        entry.expandIndicator:Hide()
+    end
     entry:SetScript("OnClick", nil)
     entry:SetScript("OnEnter", nil)
     entry:SetScript("OnLeave", nil)
@@ -366,11 +387,12 @@ local function OnEntryLeave()
 end
 
 local function OnEntryClick(self, _button)
-    if not self.itemLink then return end
+    if not self.itemLink then
+        return
+    end
 
     local db = ns.Addon.db.profile
-    local canExpand = db.history.showRollDetails and self._rollResults
-        and #self._rollResults > 0
+    local canExpand = db.history.showRollDetails and self._rollResults and #self._rollResults > 0
 
     -- Shift-click always inserts item link
     if IsShiftKeyDown() then
@@ -416,8 +438,7 @@ local function PopulateEntryDetails(entry, rollResults)
 
     for idx, result in ipairs(rollResults) do
         local row = AcquireDetailRow(entry.detailContainer)
-        row:SetPoint("TOPLEFT", entry.detailContainer, "TOPLEFT", 0,
-            -((idx - 1) * DETAIL_ROW_HEIGHT))
+        row:SetPoint("TOPLEFT", entry.detailContainer, "TOPLEFT", 0, -((idx - 1) * DETAIL_ROW_HEIGHT))
         row:SetPoint("RIGHT", entry.detailContainer, "RIGHT", 0, 0)
 
         -- Font
@@ -549,11 +570,15 @@ end
 -------------------------------------------------------------------------------
 
 local function UpdateScrollBar()
-    if not scrollBar or not scrollFrame then return end
+    if not scrollBar or not scrollFrame then
+        return
+    end
     local contentHeight = scrollChild:GetHeight()
     local visibleHeight = scrollFrame:GetHeight()
     local maxScroll = contentHeight - visibleHeight
-    if maxScroll < 0 then maxScroll = 0 end
+    if maxScroll < 0 then
+        maxScroll = 0
+    end
 
     scrollBar:SetMinMaxValues(0, maxScroll)
     if maxScroll == 0 then
@@ -568,7 +593,9 @@ end
 -------------------------------------------------------------------------------
 
 RefreshHistory = function()
-    if not containerFrame or not containerFrame:IsShown() then return end
+    if not containerFrame or not containerFrame:IsShown() then
+        return
+    end
 
     ReleaseAllEntries()
 
@@ -587,10 +614,8 @@ RefreshHistory = function()
         -- Variable height: base + expanded detail rows
         local thisHeight = entryHeight
         local entryKey = GetEntryKey(data)
-        if db.history.showRollDetails and expandedEntries[entryKey]
-            and data.rollResults and #data.rollResults > 0 then
-            thisHeight = entryHeight + (#data.rollResults * DETAIL_ROW_HEIGHT)
-                + DETAIL_PADDING
+        if db.history.showRollDetails and expandedEntries[entryKey] and data.rollResults and #data.rollResults > 0 then
+            thisHeight = entryHeight + (#data.rollResults * DETAIL_ROW_HEIGHT) + DETAIL_PADDING
         end
         entry:SetHeight(thisHeight)
         yOffset = yOffset + thisHeight + entrySpacing
@@ -598,7 +623,9 @@ RefreshHistory = function()
 
     -- Resize scroll child to fit all entries (use accumulated yOffset)
     local totalHeight = yOffset
-    if totalHeight < 1 then totalHeight = 1 end
+    if totalHeight < 1 then
+        totalHeight = 1
+    end
     scrollChild:SetHeight(totalHeight)
 
     UpdateScrollBar()
@@ -609,9 +636,13 @@ end
 -------------------------------------------------------------------------------
 
 local function SaveFramePosition()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile
-    if not db.history then return end
+    if not db.history then
+        return
+    end
     local point, _, relativePoint, x, y = containerFrame:GetPoint()
     if point then
         db.history.point = point
@@ -622,13 +653,22 @@ local function SaveFramePosition()
 end
 
 local function RestoreFramePosition()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile
-    if not db.history then return end
+    if not db.history then
+        return
+    end
     containerFrame:ClearAllPoints()
     if db.history.point then
-        containerFrame:SetPoint(db.history.point, UIParent, db.history.relativePoint,
-            db.history.x or 0, db.history.y or 0)
+        containerFrame:SetPoint(
+            db.history.point,
+            UIParent,
+            db.history.relativePoint,
+            db.history.x or 0,
+            db.history.y or 0
+        )
     else
         containerFrame:SetPoint("CENTER", UIParent, "CENTER", DEFAULT_HISTORY_X_OFFSET, 0)
     end
@@ -653,14 +693,12 @@ local function CreateTitleBar(parent)
     titleBar.text:SetTextColor(1, 0.82, 0)
 
     -- Close button
-    local ok, closeBtn = pcall(CreateFrame, "Button", nil, titleBar,
-        "UIPanelCloseButtonNoScripts")
+    local ok, closeBtn = pcall(CreateFrame, "Button", nil, titleBar, "UIPanelCloseButtonNoScripts")
     if not ok or not closeBtn then
         closeBtn = CreateFrame("Button", nil, titleBar)
         closeBtn:SetNormalTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Up")
         closeBtn:SetPushedTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Down")
-        closeBtn:SetHighlightTexture(
-            "Interface\\Buttons\\UI-Panel-MinimizeButton-Highlight")
+        closeBtn:SetHighlightTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Highlight")
     end
     closeBtn:SetSize(24, 24)
     closeBtn:SetPoint("TOPRIGHT", titleBar, "TOPRIGHT", -2, -2)
@@ -777,7 +815,9 @@ local function CreateContainerFrame()
 
     frame:SetScript("OnDragStart", function(self)
         local db = ns.Addon.db.profile
-        if db.history.lock then return end
+        if db.history.lock then
+            return
+        end
         self:StartMoving()
     end)
 
@@ -796,9 +836,13 @@ end
 local timeRefreshHandle
 
 local function StartTimeRefresh()
-    if timeRefreshHandle then return end
+    if timeRefreshHandle then
+        return
+    end
     timeRefreshHandle = ns.Addon:ScheduleRepeatingTimer(function()
-        if not containerFrame or not containerFrame:IsShown() then return end
+        if not containerFrame or not containerFrame:IsShown() then
+            return
+        end
         for _, entry in ipairs(activeEntries) do
             if entry.timestampValue then
                 entry.timeText:SetText(FormatTimeAgo(entry.timestampValue))
@@ -819,7 +863,9 @@ end
 -------------------------------------------------------------------------------
 
 function ns.HistoryFrame.Initialize()
-    if containerFrame then return end
+    if containerFrame then
+        return
+    end
     containerFrame = CreateContainerFrame()
     scrollFrame, scrollChild, scrollBar = CreateScrollComponents(containerFrame)
     ApplyLayoutOffsets(containerFrame)
@@ -830,29 +876,39 @@ end
 
 function ns.HistoryFrame.Shutdown()
     StopTimeRefresh()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     ReleaseAllEntries()
     containerFrame:Hide()
     ns.DebugPrint("HistoryFrame shut down")
 end
 
 function ns.HistoryFrame.Show()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile
-    if not db.history.enabled then return end
+    if not db.history.enabled then
+        return
+    end
     containerFrame:Show()
     RefreshHistory()
     StartTimeRefresh()
 end
 
 function ns.HistoryFrame.Hide()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     StopTimeRefresh()
     containerFrame:Hide()
 end
 
 function ns.HistoryFrame.Toggle()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     if containerFrame:IsShown() then
         ns.HistoryFrame.Hide()
     else
@@ -865,7 +921,9 @@ function ns.HistoryFrame.Refresh()
 end
 
 function ns.HistoryFrame.ApplySettings()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
 
     -- Update backdrop
     ApplyBackdrop(containerFrame)
@@ -965,7 +1023,9 @@ function ns.HistoryFrame.SetEntries(entries)
     -- Replace all data
     wipe(ns.historyData)
     for i, entry in ipairs(entries) do
-        if i > maxEntries then break end
+        if i > maxEntries then
+            break
+        end
         ns.historyData[i] = entry
     end
 

--- a/DragonLoot/Display/LootAnimations.lua
+++ b/DragonLoot/Display/LootAnimations.lua
@@ -40,7 +40,9 @@ ns.LootAnimations.isClosing = false
 --- Restore the frame's anchor to the saved DB position so the next open starts correctly.
 local function RestoreDbAnchor(frame)
     local db = ns.Addon.db and ns.Addon.db.profile.lootWindow
-    if not db then return end
+    if not db then
+        return
+    end
     frame:ClearAllPoints()
     if db.point then
         frame:SetPoint(db.point, UIParent, db.relativePoint, db.x or 0, db.y or 0)
@@ -99,15 +101,16 @@ function ns.LootAnimations.PlayClose(frame, onFinished)
 
     if not db.animation.enabled then
         ns.LootAnimations.isClosing = false
-        if onFinished then onFinished() end
+        if onFinished then
+            onFinished()
+        end
         return
     end
 
     local duration = db.animation.closeDuration or 0.5
 
     -- Snapshot where the frame visually is RIGHT NOW (mid-open-animation or idle).
-    local curAlpha, curScale, curPoint, curRelTo, curRelPoint, curX, curY =
-        DU.CaptureVisualState(frame)
+    local curAlpha, curScale, curPoint, curRelTo, curRelPoint, curX, curY = DU.CaptureVisualState(frame)
 
     -- StopAll restores the frame to its pre-animation state (e.g. alpha=0 if the
     -- open animation was still running). We immediately overwrite with the snapshot
@@ -129,7 +132,9 @@ function ns.LootAnimations.PlayClose(frame, onFinished)
             RestoreDbAnchor(frame)
 
             ns.LootAnimations.isClosing = false
-            if onFinished then onFinished() end
+            if onFinished then
+                onFinished()
+            end
         end,
     })
     if not ok then
@@ -139,7 +144,9 @@ function ns.LootAnimations.PlayClose(frame, onFinished)
         frame:Hide()
         RestoreDbAnchor(frame)
         ns.LootAnimations.isClosing = false
-        if onFinished then onFinished() end
+        if onFinished then
+            onFinished()
+        end
     end
 end
 

--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -56,13 +56,13 @@ local BIND_LABELS = {
 local TITLE_BAR_HEIGHT = 24
 local MIN_QUALITY_RARE = 3
 local ICON_GLOW_PADDING = 25
-local SLOT_ICON_LEFT_INSET = 4    -- icon frame left offset from slot LEFT edge
-local ICON_BORDER_INSET = 2       -- icon border bleed beyond icon frame edge (each side)
-local SLOT_TEXT_LEFT_GAP = 6      -- gap between icon right edge and item name left
-local SLOT_TEXT_TOP_OFFSET = 2    -- item name top inset below icon frame top
-local SLOT_SUBTEXT_GAP = 1        -- vertical gap between item name bottom and sub-text top
-local SLOT_TEXT_RIGHT_INSET = 4   -- text right offset from slot RIGHT edge
-local SLOT_QUANTITY_OFFSET = 2    -- quantity badge bleed beyond icon frame corner
+local SLOT_ICON_LEFT_INSET = 4 -- icon frame left offset from slot LEFT edge
+local ICON_BORDER_INSET = 2 -- icon border bleed beyond icon frame edge (each side)
+local SLOT_TEXT_LEFT_GAP = 6 -- gap between icon right edge and item name left
+local SLOT_TEXT_TOP_OFFSET = 2 -- item name top inset below icon frame top
+local SLOT_SUBTEXT_GAP = 1 -- vertical gap between item name bottom and sub-text top
+local SLOT_TEXT_RIGHT_INSET = 4 -- text right offset from slot RIGHT edge
+local SLOT_QUANTITY_OFFSET = 2 -- quantity badge bleed beyond icon frame corner
 
 local function GetSlotSpacing()
     return ns.Addon.db.profile.lootWindow.slotSpacing or 2
@@ -98,13 +98,11 @@ local containerFrame
 
 local function GetNormalizedSlotInfo(slotIndex)
     if isRetail then
-        local icon, name, quantity, _, quality, locked, isQuestItem =
-            GetLootSlotInfo(slotIndex)
+        local icon, name, quantity, _, quality, locked, isQuestItem = GetLootSlotInfo(slotIndex)
         return icon, name, quantity, quality, locked, isQuestItem
     end
     -- Classic/TBC/MoP: 6 returns with currencyID at position 4, no isQuestItem
-    local icon, name, quantity, _, quality, locked =
-        GetLootSlotInfo(slotIndex)
+    local icon, name, quantity, _, quality, locked = GetLootSlotInfo(slotIndex)
     return icon, name, quantity, quality, locked, nil
 end
 
@@ -114,13 +112,16 @@ end
 
 local function GetItemDetails(slotIndex)
     local lootType = GetLootSlotType(slotIndex)
-    if lootType ~= LOOT_SLOT_ITEM then return nil, nil, nil end
+    if lootType ~= LOOT_SLOT_ITEM then
+        return nil, nil, nil
+    end
 
     local itemLink = GetLootSlotLink(slotIndex)
-    if not itemLink then return nil, nil, nil end
+    if not itemLink then
+        return nil, nil, nil
+    end
 
-    local _, _, _, itemLevel, _, _, itemSubType, _,
-          _, _, _, _, _, bindType = C_Item.GetItemInfo(itemLink)
+    local _, _, _, itemLevel, _, _, itemSubType, _, _, _, _, _, _, bindType = C_Item.GetItemInfo(itemLink)
 
     local bindText = bindType and BIND_LABELS[bindType] or nil
     return itemLevel, bindText, itemSubType
@@ -140,9 +141,7 @@ local function ApplySlotBackground(slot, quality)
 
     if style == "gradient" then
         slot.rowBg:SetColorTexture(1, 1, 1)
-        slot.rowBg:SetGradient("HORIZONTAL",
-            CreateColor(r, g, b, 0.4),
-            CreateColor(r, g, b, 0.1))
+        slot.rowBg:SetGradient("HORIZONTAL", CreateColor(r, g, b, 0.4), CreateColor(r, g, b, 0.1))
         slot.rowBg:Show()
         slot.accentStripe:Hide()
     elseif style == "flat" then
@@ -211,8 +210,13 @@ local function ApplyLayoutOffsets(frame)
     if frame.titleSeparator then
         frame.titleSeparator:ClearAllPoints()
         frame.titleSeparator:SetPoint("TOPLEFT", frame, "TOPLEFT", 6 + borderSize, -(TITLE_BAR_HEIGHT + borderSize))
-        frame.titleSeparator:SetPoint("TOPRIGHT", frame, "TOPRIGHT",
-            -(6 + borderSize), -(TITLE_BAR_HEIGHT + borderSize))
+        frame.titleSeparator:SetPoint(
+            "TOPRIGHT",
+            frame,
+            "TOPRIGHT",
+            -(6 + borderSize),
+            -(TITLE_BAR_HEIGHT + borderSize)
+        )
     end
 end
 
@@ -221,7 +225,9 @@ end
 -------------------------------------------------------------------------------
 
 local function SaveFramePosition()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile.lootWindow
     local point, _, relativePoint, x, y = containerFrame:GetPoint()
     if point then
@@ -233,7 +239,9 @@ local function SaveFramePosition()
 end
 
 local function RestoreFramePosition()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile.lootWindow
     containerFrame:ClearAllPoints()
     if db.point then
@@ -244,7 +252,9 @@ local function RestoreFramePosition()
 end
 
 local function PositionAtCursor()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local x, y = GetCursorPosition()
     local scale = containerFrame:GetEffectiveScale()
     containerFrame:ClearAllPoints()
@@ -285,10 +295,7 @@ local function OnSlotEnter(self)
     end
 
     -- Brighten item name
-    self.itemName:SetTextColor(
-        math.min(r + 0.15, 1),
-        math.min(g + 0.15, 1),
-        math.min(b + 0.15, 1))
+    self.itemName:SetTextColor(math.min(r + 0.15, 1), math.min(g + 0.15, 1), math.min(b + 0.15, 1))
 end
 
 local function OnSlotLeave(self)
@@ -413,7 +420,9 @@ local function AcquireSlot()
 end
 
 local function ReleaseSlot(slot)
-    if slot._isPooled then return end
+    if slot._isPooled then
+        return
+    end
     slot._isPooled = true
 
     slot.iconBorder:Hide()
@@ -467,7 +476,9 @@ end
 
 local function BuildSlotData(slotIndex)
     local icon, name, quantity, quality, locked, isQuestItem = GetNormalizedSlotInfo(slotIndex)
-    if not icon then return nil end
+    if not icon then
+        return nil
+    end
 
     local lootType = GetLootSlotType(slotIndex)
     local subText = BuildSubText(slotIndex, lootType)
@@ -621,10 +632,7 @@ local function RenderSlot(slot, data, isTest)
             if self.iconGlow:IsShown() then
                 self.iconGlow:SetAlpha(0.9)
             end
-            self.itemName:SetTextColor(
-                math.min(r + 0.15, 1),
-                math.min(g + 0.15, 1),
-                math.min(b + 0.15, 1))
+            self.itemName:SetTextColor(math.min(r + 0.15, 1), math.min(g + 0.15, 1), math.min(b + 0.15, 1))
         end)
         slot:SetScript("OnLeave", function(self)
             GameTooltip:Hide()
@@ -749,7 +757,9 @@ end
 -------------------------------------------------------------------------------
 
 local function LayoutSlots()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile
     local iconSize = db.appearance.lootIconSize or 36
     local borderSize = db.appearance.borderSize or 1
@@ -767,10 +777,15 @@ local function LayoutSlots()
     end
 
     -- Auto-resize container height to fit slots
-    local totalHeight = TITLE_BAR_HEIGHT + padding
-        + (#activeSlots * (slotHeight + slotSpacing)) + padding + (borderSize * 2)
+    local totalHeight = TITLE_BAR_HEIGHT
+        + padding
+        + (#activeSlots * (slotHeight + slotSpacing))
+        + padding
+        + (borderSize * 2)
     local minHeight = db.lootWindow.height or 300
-    if totalHeight < minHeight then totalHeight = minHeight end
+    if totalHeight < minHeight then
+        totalHeight = minHeight
+    end
     containerFrame:SetHeight(totalHeight)
 end
 
@@ -787,7 +802,9 @@ end
 -------------------------------------------------------------------------------
 
 function ns.LootFrame.Initialize()
-    if containerFrame then return end
+    if containerFrame then
+        return
+    end
     containerFrame = CreateContainerFrame()
     ns.LootFrame.ApplySettings()
     RestoreFramePosition()
@@ -795,7 +812,9 @@ function ns.LootFrame.Initialize()
 end
 
 function ns.LootFrame.Shutdown()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     ReleaseAllSlots()
     containerFrame:Hide()
     ns.DebugPrint("LootFrame shut down")
@@ -807,10 +826,14 @@ end
 
 local function EvaluateSlot(slotIndex)
     local db = ns.Addon.db
-    if not db then return false end
+    if not db then
+        return false
+    end
 
     local autoLootCfg = db.profile.autoLoot
-    if not autoLootCfg then return false end
+    if not autoLootCfg then
+        return false
+    end
 
     local slotType = GetLootSlotType(slotIndex)
 
@@ -822,32 +845,46 @@ local function EvaluateSlot(slotIndex)
     -- Item evaluation
     if slotType == LOOT_SLOT_ITEM then
         local link = GetLootSlotLink(slotIndex)
-        if not link then return false end
+        if not link then
+            return false
+        end
 
         local itemID = tonumber(link:match("item:(%d+)"))
-        if not itemID then return false end
+        if not itemID then
+            return false
+        end
 
         -- Whitelist always qualifies
-        if autoLootCfg.whitelist[itemID] then return true end
+        if autoLootCfg.whitelist[itemID] then
+            return true
+        end
 
         -- Blacklist never qualifies
-        if autoLootCfg.blacklist[itemID] then return false end
+        if autoLootCfg.blacklist[itemID] then
+            return false
+        end
 
         -- Quality check
         local _, _, _, quality = GetLootSlotInfo(slotIndex)
-        if quality and quality >= autoLootCfg.minQuality then return true end
+        if quality and quality >= autoLootCfg.minQuality then
+            return true
+        end
     end
 
     return false
 end
 
 function ns.LootFrame.Show(autoLoot)
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
 
     ReleaseAllSlots()
 
     local numItems = GetNumLootItems()
-    if numItems == 0 then return end
+    if numItems == 0 then
+        return
+    end
 
     -- Auto-loot: skip UI entirely
     if autoLoot then
@@ -886,7 +923,9 @@ function ns.LootFrame.Show(autoLoot)
             -- Fall through to show UI for remaining items
             -- Re-read numItems since some were looted
             numItems = GetNumLootItems()
-            if numItems == 0 then return end
+            if numItems == 0 then
+                return
+            end
         end
     end
 
@@ -921,7 +960,9 @@ function ns.LootFrame.Show(autoLoot)
 end
 
 function ns.LootFrame.Hide()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
 
     local function DoHide()
         ReleaseAllSlots()
@@ -937,7 +978,9 @@ function ns.LootFrame.Hide()
 end
 
 function ns.LootFrame.UpdateSlot(slotIndex)
-    if not containerFrame or not containerFrame:IsShown() then return end
+    if not containerFrame or not containerFrame:IsShown() then
+        return
+    end
 
     -- Find the active slot matching this index
     for i = #activeSlots, 1, -1 do
@@ -967,7 +1010,9 @@ function ns.LootFrame.UpdateSlot(slotIndex)
 end
 
 function ns.LootFrame.ApplySettings()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile
 
     containerFrame:SetSize(db.lootWindow.width or 250, db.lootWindow.height or 300)
@@ -1019,7 +1064,9 @@ function ns.LootFrame.ApplySettings()
 end
 
 function ns.LootFrame.ResetAnchor()
-    if not containerFrame then return end
+    if not containerFrame then
+        return
+    end
     local db = ns.Addon.db.profile.lootWindow
     db.point = nil
     db.relativePoint = nil
@@ -1039,29 +1086,59 @@ end
 
 local TEST_ITEMS = {
     {
-        icon = 134762, name = "Super Mana Potion", quantity = 3, quality = 1,
-        slotType = LOOT_SLOT_ITEM, isQuestItem = false,
-        itemLevel = 0, bindType = 0, itemSubType = "Potion",
+        icon = 134762,
+        name = "Super Mana Potion",
+        quantity = 3,
+        quality = 1,
+        slotType = LOOT_SLOT_ITEM,
+        isQuestItem = false,
+        itemLevel = 0,
+        bindType = 0,
+        itemSubType = "Potion",
     },
     {
-        icon = 132608, name = "Bog Walker's Bands", quantity = 1, quality = 2,
-        slotType = LOOT_SLOT_ITEM, isQuestItem = false,
-        itemLevel = 115, bindType = 2, itemSubType = "Leather",
+        icon = 132608,
+        name = "Bog Walker's Bands",
+        quantity = 1,
+        quality = 2,
+        slotType = LOOT_SLOT_ITEM,
+        isQuestItem = false,
+        itemLevel = 115,
+        bindType = 2,
+        itemSubType = "Leather",
     },
     {
-        icon = 132447, name = "Gorehowl", quantity = 1, quality = 4,
-        slotType = LOOT_SLOT_ITEM, isQuestItem = false,
-        itemLevel = 226, bindType = 1, itemSubType = "Swords",
+        icon = 132447,
+        name = "Gorehowl",
+        quantity = 1,
+        quality = 4,
+        slotType = LOOT_SLOT_ITEM,
+        isQuestItem = false,
+        itemLevel = 226,
+        bindType = 1,
+        itemSubType = "Swords",
     },
     {
-        icon = 133784, name = "15 Gold 32 Silver", quantity = 1, quality = 1,
-        slotType = LOOT_SLOT_MONEY, isQuestItem = false,
-        itemLevel = 0, bindType = 0, itemSubType = nil,
+        icon = 133784,
+        name = "15 Gold 32 Silver",
+        quantity = 1,
+        quality = 1,
+        slotType = LOOT_SLOT_MONEY,
+        isQuestItem = false,
+        itemLevel = 0,
+        bindType = 0,
+        itemSubType = nil,
     },
     {
-        icon = 132798, name = "Cenarion Spirits", quantity = 1, quality = 3,
-        slotType = LOOT_SLOT_ITEM, isQuestItem = true,
-        itemLevel = 200, bindType = 1, itemSubType = "Quest",
+        icon = 132798,
+        name = "Cenarion Spirits",
+        quantity = 1,
+        quality = 3,
+        slotType = LOOT_SLOT_ITEM,
+        isQuestItem = true,
+        itemLevel = 200,
+        bindType = 1,
+        itemSubType = "Quest",
     },
 }
 

--- a/DragonLoot/Display/RollAnimations.lua
+++ b/DragonLoot/Display/RollAnimations.lua
@@ -77,15 +77,16 @@ function ns.RollAnimations.PlayHide(frame, onFinished)
 
     if not db.animation.enabled then
         ns.RollAnimations.isClosing = false
-        if onFinished then onFinished() end
+        if onFinished then
+            onFinished()
+        end
         return
     end
 
     local duration = db.animation.closeDuration or 0.5
 
     -- Snapshot where the frame visually is RIGHT NOW (mid-show-animation or idle).
-    local curAlpha, curScale, curPoint, curRelTo, curRelPoint, curX, curY =
-        DU.CaptureVisualState(frame)
+    local curAlpha, curScale, curPoint, curRelTo, curRelPoint, curX, curY = DU.CaptureVisualState(frame)
 
     -- StopAll restores the frame to its pre-animation state (e.g. alpha=0 if the
     -- show animation was still running). We immediately overwrite with the snapshot
@@ -104,7 +105,9 @@ function ns.RollAnimations.PlayHide(frame, onFinished)
             frame:Hide()
 
             ns.RollAnimations.isClosing = false
-            if onFinished then onFinished() end
+            if onFinished then
+                onFinished()
+            end
         end,
     })
     if not ok then
@@ -113,7 +116,9 @@ function ns.RollAnimations.PlayHide(frame, onFinished)
         frame:SetScale(scale)
         frame:Hide()
         ns.RollAnimations.isClosing = false
-        if onFinished then onFinished() end
+        if onFinished then
+            onFinished()
+        end
     end
 end
 

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -754,7 +754,9 @@ end
 -------------------------------------------------------------------------------
 
 local function BuildRollData(rollID)
-    local texture, name, count, quality, bindOnPickUp, canNeed, canGreed, canDisenchant, reasonNeed, reasonGreed, reasonDisenchant, _, canTransmog =
+    -- stylua: ignore
+    local texture, name, count, quality, bindOnPickUp, canNeed, canGreed, canDisenchant,
+        reasonNeed, reasonGreed, reasonDisenchant, _, canTransmog =
         GetLootRollItemInfo(rollID)
 
     if not texture then

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -40,7 +40,9 @@ end
 
 local function ApplyTimerBarBorder(container)
     local rollCfg = GetRollFrameDB()
-    if not rollCfg then return end
+    if not rollCfg then
+        return
+    end
     if rollCfg.timerBarBorder then
         container:SetBackdrop({
             edgeFile = DU.WHITE8x8,
@@ -81,10 +83,10 @@ local ROLL_TRANSMOG = 4
 
 local TEST_ROLLS = {
     {
-        texture = 132447,           -- Gorehowl
+        texture = 132447, -- Gorehowl
         name = "Gorehowl",
         count = 1,
-        quality = 4,                -- Epic
+        quality = 4, -- Epic
         bindOnPickUp = true,
         canNeed = true,
         canGreed = true,
@@ -93,10 +95,10 @@ local TEST_ROLLS = {
         duration = 15,
     },
     {
-        texture = 135506,           -- Sunfury Bow of the Phoenix
+        texture = 135506, -- Sunfury Bow of the Phoenix
         name = "Sunfury Bow of the Phoenix",
         count = 1,
-        quality = 4,                -- Epic
+        quality = 4, -- Epic
         bindOnPickUp = true,
         canNeed = true,
         canGreed = true,
@@ -105,13 +107,13 @@ local TEST_ROLLS = {
         duration = 20,
     },
     {
-        texture = 133280,           -- Blazefury, Reborn (fire sword icon)
+        texture = 133280, -- Blazefury, Reborn (fire sword icon)
         name = "Blazefury, Reborn",
         count = 1,
-        quality = 4,                -- Epic
+        quality = 4, -- Epic
         bindOnPickUp = true,
         canNeed = true,
-        canGreed = false,           -- Greed disabled when Transmog available
+        canGreed = false, -- Greed disabled when Transmog available
         canDisenchant = true,
         canTransmog = true,
         duration = 15,
@@ -135,8 +137,8 @@ local MAX_VISIBLE_ROLLS = 4
 local DEFAULT_ROLL_ANCHOR_Y = -200
 local ROLL_FRAME_EXTRA_HEIGHT = 18
 local TEST_ROLL_TICK_INTERVAL = 0.1
-local ROLL_TEXT_LEFT_GAP = 6      -- gap between icon right edge and text/timer-bar left
-local ROLL_TIMER_RIGHT_GAP = 2    -- timer bar right inset from frame RIGHT edge
+local ROLL_TEXT_LEFT_GAP = 6 -- gap between icon right edge and text/timer-bar left
+local ROLL_TIMER_RIGHT_GAP = 2 -- timer bar right inset from frame RIGHT edge
 
 -- Returns the left content inset (icon width + padding + text gap + border thickness).
 -- Used by both ApplyTextLayoutOffsets and ApplyTimerBarOffsets to keep the left
@@ -242,7 +244,9 @@ end
 local function CalculateFrameHeight(iconSize)
     local db = ns.Addon.db.profile
     local rollFrameDB = GetRollFrameDB()
-    if not rollFrameDB then return GetFrameMinHeight() end
+    if not rollFrameDB then
+        return GetFrameMinHeight()
+    end
     local effectiveIconSize = (rollFrameDB.iconPosition == "outside") and 0 or iconSize
     if rollFrameDB.compactTextLayout then
         local padding = GetContentPadding()
@@ -270,14 +274,18 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
     local contentLeftInset = GetRollContentLeftInset(iconSize, padding, borderSize)
     -- Item name top-left anchor (shared by both modes)
     frame.itemName:ClearAllPoints()
-    frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT",
-        contentLeftInset, -(padding + borderSize))
+    frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT", contentLeftInset, -(padding + borderSize))
 
     if compact then
         -- Compact: buttons sit on the same row as the item name
         frame.passButton:ClearAllPoints()
-        frame.passButton:SetPoint("RIGHT", frame, "RIGHT",
-            -(GetRollContentRightInset(iconSize, padding, borderSize)), 0)
+        frame.passButton:SetPoint(
+            "RIGHT",
+            frame,
+            "RIGHT",
+            -(GetRollContentRightInset(iconSize, padding, borderSize)),
+            0
+        )
         frame.passButton:SetPoint("TOP", frame, "TOP", 0, -(padding + borderSize))
 
         -- needButton is always the leftmost button (transmog occupies greed's slot to the right).
@@ -297,8 +305,7 @@ local function ApplyTextLayoutOffsets(frame, compact, iconSize, padding, borderS
         end
     else
         -- Normal: stacked rows
-        frame.itemName:SetPoint("RIGHT", frame, "RIGHT",
-            -(GetRollContentRightInset(iconSize, padding, borderSize)), 0)
+        frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -(GetRollContentRightInset(iconSize, padding, borderSize)), 0)
 
         frame.bindText:ClearAllPoints()
         frame.bindText:SetPoint("TOPLEFT", frame.itemName, "BOTTOMLEFT", 0, -rowSpacing)
@@ -324,10 +331,14 @@ local function ApplyTimerBarOffsets(frame, rollFrameDB, iconSize, padding, borde
         -- Normal: indented past icon, configurable height, text visible
         local barHeight = (rollFrameDB and rollFrameDB.timerBarHeight) or 12
         timerBarAnchor:SetHeight(barHeight)
-        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",
-            contentLeftInset, timerBarSpacing + borderSize)
-        timerBarAnchor:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-            -(padding + ROLL_TIMER_RIGHT_GAP + borderSize), timerBarSpacing + borderSize)
+        timerBarAnchor:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", contentLeftInset, timerBarSpacing + borderSize)
+        timerBarAnchor:SetPoint(
+            "BOTTOMRIGHT",
+            frame,
+            "BOTTOMRIGHT",
+            -(padding + ROLL_TIMER_RIGHT_GAP + borderSize),
+            timerBarSpacing + borderSize
+        )
         frame.timerBar.text:Show()
     end
 end
@@ -381,7 +392,9 @@ local function GetTimerBarColor(timeLeft, rollTime)
     end
 
     -- Gradient: green -> yellow -> red
-    if rollTime <= 0 then return 1, 0, 0 end
+    if rollTime <= 0 then
+        return 1, 0, 0
+    end
     local ratio = timeLeft / rollTime
 
     if ratio > 0.5 then
@@ -398,9 +411,13 @@ end
 -------------------------------------------------------------------------------
 
 local function SaveFramePosition()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = GetRollFrameDB()
-    if not db then return end
+    if not db then
+        return
+    end
     local point, _, relativePoint, x, y = anchorFrame:GetPoint()
     if point then
         db.point = point
@@ -411,9 +428,13 @@ local function SaveFramePosition()
 end
 
 local function RestoreFramePosition()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = GetRollFrameDB()
-    if not db then return end
+    if not db then
+        return
+    end
     anchorFrame:ClearAllPoints()
     if db.point then
         anchorFrame:SetPoint(db.point, UIParent, db.relativePoint, db.x or 0, db.y or 0)
@@ -505,7 +526,9 @@ local function OnIconClick(self, button)
         ns.Print(L["Test item: "] .. (frame.testItemName or L["Test Item"]))
         return
     end
-    if not frame.rollID then return end
+    if not frame.rollID then
+        return
+    end
     if button == "LeftButton" then
         local link = GetLootRollItemLink(frame.rollID)
         if link then
@@ -574,8 +597,7 @@ end
 local function CreateTimerBar(parent)
     local rollFrameDB = GetRollFrameDB() or {}
     local barHeight = rollFrameDB.timerBarHeight or 12
-    local barTexture = LSM:Fetch("statusbar", rollFrameDB.timerBarTexture)
-        or "Interface\\TargetingFrame\\UI-StatusBar"
+    local barTexture = LSM:Fetch("statusbar", rollFrameDB.timerBarTexture) or "Interface\\TargetingFrame\\UI-StatusBar"
 
     -- Container (creation-time stubs; real position set by ApplyTimerBarOffsets)
     local container = CreateFrame("Frame", nil, parent, "BackdropTemplate")
@@ -623,7 +645,7 @@ local function CreateRollFrame(index)
 
     -- Drag: propagate movement to the shared anchor frame
     frame:EnableMouse(true)
-    frame:SetMovable(false)  -- frame itself doesn't move; anchor does
+    frame:SetMovable(false) -- frame itself doesn't move; anchor does
     frame:RegisterForDrag("LeftButton")
 
     frame:SetScript("OnDragStart", function()
@@ -695,7 +717,9 @@ end
 -------------------------------------------------------------------------------
 
 local function SetButtonState(btn, canUse, reason)
-    if not btn then return end
+    if not btn then
+        return
+    end
     if canUse then
         btn:Enable()
         btn.icon:SetDesaturated(false)
@@ -730,11 +754,12 @@ end
 -------------------------------------------------------------------------------
 
 local function BuildRollData(rollID)
-    local texture, name, count, quality, bindOnPickUp, canNeed, canGreed,
-          canDisenchant, reasonNeed, reasonGreed, reasonDisenchant,
-          _, canTransmog = GetLootRollItemInfo(rollID)
+    local texture, name, count, quality, bindOnPickUp, canNeed, canGreed, canDisenchant, reasonNeed, reasonGreed, reasonDisenchant, _, canTransmog =
+        GetLootRollItemInfo(rollID)
 
-    if not texture then return nil end
+    if not texture then
+        return nil
+    end
 
     return {
         texture = texture,
@@ -874,8 +899,7 @@ local function RenderRollFrame(frame, data, rollID, isTest)
     -- Item level overlay on icon (bottom-left corner)
     if ns.Addon.db.profile.appearance.showItemLevel and not isTest then
         local link = GetLootRollItemLink(rollID)
-        local ilvl = link and C_Item and C_Item.GetDetailedItemLevelInfo and
-            C_Item.GetDetailedItemLevelInfo(link)
+        local ilvl = link and C_Item and C_Item.GetDetailedItemLevelInfo and C_Item.GetDetailedItemLevelInfo(link)
         if not frame.iconFrame.ilvl then
             frame.iconFrame.ilvl = frame.iconFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
             frame.iconFrame.ilvl:SetPoint("BOTTOMLEFT", frame.iconFrame, "BOTTOMLEFT", 2, 2)
@@ -888,11 +912,17 @@ local function RenderRollFrame(frame, data, rollID, isTest)
             frame.iconFrame.ilvl:Hide()
             local capturedRollID = rollID
             C_Timer.After(0.5, function()
-                if not frame or not frame:IsShown() then return end
-                if frame.rollID ~= capturedRollID then return end
+                if not frame or not frame:IsShown() then
+                    return
+                end
+                if frame.rollID ~= capturedRollID then
+                    return
+                end
                 local retryLink = GetLootRollItemLink(capturedRollID)
-                local retryIlvl = retryLink and C_Item and C_Item.GetDetailedItemLevelInfo and
-                    C_Item.GetDetailedItemLevelInfo(retryLink)
+                local retryIlvl = retryLink
+                    and C_Item
+                    and C_Item.GetDetailedItemLevelInfo
+                    and C_Item.GetDetailedItemLevelInfo(retryLink)
                 if retryIlvl and frame.iconFrame.ilvl then
                     frame.iconFrame.ilvl:SetText(retryIlvl)
                     frame.iconFrame.ilvl:Show()
@@ -945,7 +975,9 @@ end
 
 local function PopulateRollFrame(frame, rollID)
     local data = BuildRollData(rollID)
-    if not data then return end
+    if not data then
+        return
+    end
     RenderRollFrame(frame, data, rollID, false)
 end
 
@@ -978,7 +1010,9 @@ end
 
 local function ReleaseRollFrame(index)
     local frame = rollFramePool[index]
-    if not frame then return end
+    if not frame then
+        return
+    end
     if frame.testTimer then
         frame.testTimer:Cancel()
         frame.testTimer = nil
@@ -1033,7 +1067,9 @@ end
 
 local function StartTestTimer(frameIndex, duration)
     local frame = rollFramePool[frameIndex]
-    if not frame or not frame:IsShown() then return end
+    if not frame or not frame:IsShown() then
+        return
+    end
 
     local remaining = duration
     local total = duration
@@ -1069,7 +1105,9 @@ local function SpawnOneTestRoll()
             break
         end
     end
-    if not freeIndex then return end
+    if not freeIndex then
+        return
+    end
 
     loopRollIndex = loopRollIndex + 1
     local testData = TEST_ROLLS[((loopRollIndex - 1) % #TEST_ROLLS) + 1]
@@ -1088,9 +1126,13 @@ end
 -- Returns the vertical component of a WoW anchor point string (strips LEFT/RIGHT).
 -- Used by CenterHorizontally to normalize the saved anchor before zeroing x.
 local function VerticalComponent(p)
-    if p:find("TOP") then return "TOP"
-    elseif p:find("BOTTOM") then return "BOTTOM"
-    else return "CENTER" end
+    if p:find("TOP") then
+        return "TOP"
+    elseif p:find("BOTTOM") then
+        return "BOTTOM"
+    else
+        return "CENTER"
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -1109,14 +1151,18 @@ function ns.RollFrame.Initialize()
 end
 
 function ns.RollFrame.Shutdown()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     ns.RollFrame.HideAllRolls()
     anchorFrame:Hide()
     ns.DebugPrint("RollFrame shut down")
 end
 
 function ns.RollFrame.ShowRoll(frameIndex, rollID)
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
 
     local frame = AcquireRollFrame(frameIndex)
     PopulateRollFrame(frame, rollID)
@@ -1133,7 +1179,9 @@ function ns.RollFrame.HideRoll(frameIndex, onComplete)
     local frame = rollFramePool[frameIndex]
     if not frame or not frame:IsShown() then
         ReleaseRollFrame(frameIndex)
-        if onComplete then onComplete() end
+        if onComplete then
+            onComplete()
+        end
         return
     end
 
@@ -1141,7 +1189,9 @@ function ns.RollFrame.HideRoll(frameIndex, onComplete)
     ns.RollAnimations.PlayHide(frame, function()
         ReleaseRollFrame(frameIndex)
         LayoutRollFrames()
-        if onComplete then onComplete() end
+        if onComplete then
+            onComplete()
+        end
     end)
 end
 
@@ -1158,7 +1208,9 @@ end
 
 function ns.RollFrame.UpdateTimer(frameIndex, timeLeft, rollTime)
     local frame = rollFramePool[frameIndex]
-    if not frame or not frame:IsShown() then return end
+    if not frame or not frame:IsShown() then
+        return
+    end
 
     local bar = frame.timerBar
     bar:SetMinMaxValues(0, rollTime)
@@ -1173,9 +1225,13 @@ function ns.RollFrame.UpdateTimer(frameIndex, timeLeft, rollTime)
 end
 
 function ns.RollFrame.ApplySettings()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = ns.Addon.db.profile
-    if not db then return end
+    if not db then
+        return
+    end
 
     local appearance = db.appearance or {}
     local rollFrame = db.rollFrame or {}
@@ -1184,8 +1240,7 @@ function ns.RollFrame.ApplySettings()
     anchorFrame:SetWidth(GetFrameWidth())
 
     local barHeight = rollFrame.timerBarHeight or 12
-    local barTexture = LSM:Fetch("statusbar", rollFrame.timerBarTexture)
-        or "Interface\\TargetingFrame\\UI-StatusBar"
+    local barTexture = LSM:Fetch("statusbar", rollFrame.timerBarTexture) or "Interface\\TargetingFrame\\UI-StatusBar"
     local fontPath, fontSize, fontOutline = GetFont()
     local iconSize = GetRollIconSize()
 
@@ -1236,8 +1291,7 @@ function ns.RollFrame.ApplySettings()
 
             -- Update timer bar background color
             local bgColor = rollFrame.timerBarBackgroundColor or { r = 0.1, g = 0.1, b = 0.1 }
-            frame.timerBar.bg:SetColorTexture(bgColor.r, bgColor.g, bgColor.b,
-                rollFrame.timerBarBackgroundAlpha or 0.5)
+            frame.timerBar.bg:SetColorTexture(bgColor.r, bgColor.g, bgColor.b, rollFrame.timerBarBackgroundAlpha or 0.5)
 
             -- Update fonts
             frame.itemName:SetFont(fontPath, fontSize, fontOutline)
@@ -1263,8 +1317,10 @@ function ns.RollFrame.ApplySettings()
             if frame.iconFrame.ilvl then
                 if appearance.showItemLevel and frame.rollID and frame:IsShown() then
                     local link = GetLootRollItemLink(frame.rollID)
-                    local ilvl = link and C_Item and C_Item.GetDetailedItemLevelInfo and
-                        C_Item.GetDetailedItemLevelInfo(link)
+                    local ilvl = link
+                        and C_Item
+                        and C_Item.GetDetailedItemLevelInfo
+                        and C_Item.GetDetailedItemLevelInfo(link)
                     if ilvl then
                         frame.iconFrame.ilvl:SetText(ilvl)
                         frame.iconFrame.ilvl:Show()
@@ -1282,9 +1338,13 @@ function ns.RollFrame.ApplySettings()
 end
 
 function ns.RollFrame.ResetAnchor()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = GetRollFrameDB()
-    if not db then return end
+    if not db then
+        return
+    end
     db.point = nil
     db.relativePoint = nil
     db.x = nil
@@ -1294,9 +1354,13 @@ function ns.RollFrame.ResetAnchor()
 end
 
 function ns.RollFrame.CenterHorizontally()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = GetRollFrameDB()
-    if not db then return end
+    if not db then
+        return
+    end
     local y = db.y or DEFAULT_ROLL_ANCHOR_Y
     -- Normalize anchor to strip any LEFT/RIGHT component so x=0 truly centers
     local newPoint = VerticalComponent(db.point or "TOP")
@@ -1310,9 +1374,13 @@ function ns.RollFrame.CenterHorizontally()
 end
 
 function ns.RollFrame.CenterVertically()
-    if not anchorFrame then return end
+    if not anchorFrame then
+        return
+    end
     local db = GetRollFrameDB()
-    if not db then return end
+    if not db then
+        return
+    end
     local x = db.x or 0
     -- Normalize anchor to CENTER/CENTER so y=0 is truly vertical center
     db.point = "CENTER"

--- a/DragonLoot/Display/RollManager.lua
+++ b/DragonLoot/Display/RollManager.lua
@@ -80,14 +80,14 @@ end
 -------------------------------------------------------------------------------
 
 local addon
-local activeRolls = {}      -- rollID -> { rollID, rollTime, startTime, frameIndex }
-local waitingRolls = {}     -- ordered list of { rollID, rollTime }
-local usedFrames = {}       -- frameIndex -> true/false
-local notifiedRolls = {}    -- rollID -> true (prevent duplicate winner notifications)
+local activeRolls = {} -- rollID -> { rollID, rollTime, startTime, frameIndex }
+local waitingRolls = {} -- ordered list of { rollID, rollTime }
+local usedFrames = {} -- frameIndex -> true/false
+local notifiedRolls = {} -- rollID -> true (prevent duplicate winner notifications)
 local activeRollCount = 0
 local timerHandle
 local lifecycleState = LifecycleUtil.CreateState()
-local HideAfterVote         -- forward declaration; defined after helpers
+local HideAfterVote -- forward declaration; defined after helpers
 
 -------------------------------------------------------------------------------
 -- StaticPopup for roll confirmations (shared by Retail and Classic listeners)
@@ -98,7 +98,9 @@ StaticPopupDialogs["DRAGONLOOT_CONFIRM_LOOT_ROLL"] = {
     button1 = YES,
     button2 = NO,
     OnAccept = function(self)
-        if not self.data then return end
+        if not self.data then
+            return
+        end
         ConfirmLootRoll(self.data.rollID, self.data.rollType)
         -- Hide frame after confirming BoP roll if configured
         local db = ns.Addon.db
@@ -157,8 +159,12 @@ local function OnTimerTick()
 end
 
 local function StartTimer()
-    if timerHandle then return end
-    if not addon then return end
+    if timerHandle then
+        return
+    end
+    if not addon then
+        return
+    end
     timerHandle = addon:ScheduleRepeatingTimer(OnTimerTick, TIMER_INTERVAL)
 end
 
@@ -168,7 +174,9 @@ end
 
 local function IsInWaitingQueue(rollID)
     for _, entry in ipairs(waitingRolls) do
-        if entry.rollID == rollID then return true end
+        if entry.rollID == rollID then
+            return true
+        end
     end
     return false
 end
@@ -188,14 +196,22 @@ end
 -------------------------------------------------------------------------------
 
 local function PromoteFromQueue()
-    if #waitingRolls == 0 then return end
-    if activeRollCount >= MAX_VISIBLE_ROLLS then return end
+    if #waitingRolls == 0 then
+        return
+    end
+    if activeRollCount >= MAX_VISIBLE_ROLLS then
+        return
+    end
 
     local entry = table.remove(waitingRolls, 1)
-    if not entry then return end
+    if not entry then
+        return
+    end
 
     local frameIndex = AcquireFrameIndex()
-    if not frameIndex then return end
+    if not frameIndex then
+        return
+    end
 
     activeRolls[entry.rollID] = {
         rollID = entry.rollID,
@@ -229,26 +245,38 @@ end
 -------------------------------------------------------------------------------
 
 local function SendRollWonNotification(rollID, winnerName, _, rollType, rollValue)
-    if notifiedRolls[rollID] then return end
+    if notifiedRolls[rollID] then
+        return
+    end
     notifiedRolls[rollID] = true
 
     local roll = activeRolls[rollID]
-    if not roll or not roll.itemName then return end
+    if not roll or not roll.itemName then
+        return
+    end
 
     local db = ns.Addon.db.profile
-    if not db.rollNotifications.showRollWon then return end
+    if not db.rollNotifications.showRollWon then
+        return
+    end
 
     local playerName = UnitName("player")
     local isSelf = (winnerName == playerName)
 
     -- Check config: skip group wins if not enabled
-    if not isSelf and not db.rollNotifications.showGroupWins then return end
+    if not isSelf and not db.rollNotifications.showGroupWins then
+        return
+    end
 
     -- Instance gating
-    if not IsInstanceAllowed(db.rollNotifications) then return end
+    if not IsInstanceAllowed(db.rollNotifications) then
+        return
+    end
 
     -- Quality filter
-    if roll.itemQuality and roll.itemQuality < db.rollNotifications.minQuality then return end
+    if roll.itemQuality and roll.itemQuality < db.rollNotifications.minQuality then
+        return
+    end
 
     local rollTypeName = ns.RollTypeNames[rollType] or L["Unknown"]
 
@@ -268,8 +296,10 @@ local function SendRollWonNotification(rollID, winnerName, _, rollType, rollValu
         timestamp = GetTime(),
     })
     ns.DebugPrint(
-        "Sent DRAGONTOAST_QUEUE_TOAST (roll won) for " .. (roll.itemName or "unknown")
-        .. " won by " .. (winnerName or "unknown")
+        "Sent DRAGONTOAST_QUEUE_TOAST (roll won) for "
+            .. (roll.itemName or "unknown")
+            .. " won by "
+            .. (winnerName or "unknown")
     )
 end
 
@@ -277,25 +307,45 @@ end
 -- DragonToast integration - individual roll result notification
 -------------------------------------------------------------------------------
 
-function ns.RollManager.SendRollResultNotification(itemLink, itemName, itemQuality, itemIcon,
-                                                    playerName, _, rollType, rollValue)
+function ns.RollManager.SendRollResultNotification(
+    itemLink,
+    itemName,
+    itemQuality,
+    itemIcon,
+    playerName,
+    _,
+    rollType,
+    rollValue
+)
     local db = ns.Addon.db.profile
-    if not db.rollNotifications.showRollResults then return end
+    if not db.rollNotifications.showRollResults then
+        return
+    end
 
     -- Instance gating
-    if not IsInstanceAllowed(db.rollNotifications) then return end
+    if not IsInstanceAllowed(db.rollNotifications) then
+        return
+    end
 
     -- Quality filter
-    if itemQuality and itemQuality < db.rollNotifications.minQuality then return end
+    if itemQuality and itemQuality < db.rollNotifications.minQuality then
+        return
+    end
 
     -- Self vs group filter
     local myName = UnitName("player")
     local isSelf = (playerName == myName)
-    if isSelf and not db.rollNotifications.showSelfRolls then return end
-    if not isSelf and not db.rollNotifications.showGroupRolls then return end
+    if isSelf and not db.rollNotifications.showSelfRolls then
+        return
+    end
+    if not isSelf and not db.rollNotifications.showGroupRolls then
+        return
+    end
 
     -- Skip passes - nobody wants a toast for "Player passed"
-    if rollType == ROLL_TYPE_PASS then return end
+    if rollType == ROLL_TYPE_PASS then
+        return
+    end
 
     local rollTypeName = ns.RollTypeNames[rollType] or L["Unknown"]
     local itemID = itemLink and tonumber(itemLink:match("item:(%d+)"))
@@ -323,7 +373,9 @@ function ns.RollManager.Initialize(addonRef)
     addon = addonRef or ns.Addon
 
     local db = addon.db and addon.db.profile
-    if not db or not db.rollFrame or not db.rollFrame.enabled then return end
+    if not db or not db.rollFrame or not db.rollFrame.enabled then
+        return
+    end
 
     LifecycleUtil.Activate(lifecycleState)
 
@@ -361,7 +413,9 @@ end
 
 function ns.RollManager.StartRoll(rollID, rollTime)
     -- Guard against duplicate events
-    if activeRolls[rollID] or IsInWaitingQueue(rollID) then return end
+    if activeRolls[rollID] or IsInWaitingQueue(rollID) then
+        return
+    end
 
     -- Cache item data now while it is still available
     local texture, name, count, quality = GetLootRollItemInfo(rollID)
@@ -369,7 +423,9 @@ function ns.RollManager.StartRoll(rollID, rollTime)
 
     if activeRollCount < MAX_VISIBLE_ROLLS then
         local frameIndex = AcquireFrameIndex()
-        if not frameIndex then return end
+        if not frameIndex then
+            return
+        end
 
         activeRolls[rollID] = {
             rollID = rollID,
@@ -400,7 +456,9 @@ function ns.RollManager.StartRoll(rollID, rollTime)
 end
 
 function ns.RollManager.RecoverRoll(rollID, totalDuration, timeLeft)
-    if activeRolls[rollID] or IsInWaitingQueue(rollID) then return end
+    if activeRolls[rollID] or IsInWaitingQueue(rollID) then
+        return
+    end
 
     -- Cache item data now while it is still available
     local texture, name, count, quality = GetLootRollItemInfo(rollID)
@@ -453,11 +511,16 @@ function ns.RollManager.CancelRoll(rollID)
             end
 
             -- Defer frame release and queue promotion until hide animation completes
-            ns.RollFrame.HideRoll(frameIndex, LifecycleUtil.Guard(lifecycleState, lifecycleToken, function()
-                if activeRolls[rollID] then return end
-                ReleaseFrameIndex(frameIndex)
-                PromoteFromQueue()
-            end))
+            ns.RollFrame.HideRoll(
+                frameIndex,
+                LifecycleUtil.Guard(lifecycleState, lifecycleToken, function()
+                    if activeRolls[rollID] then
+                        return
+                    end
+                    ReleaseFrameIndex(frameIndex)
+                    PromoteFromQueue()
+                end)
+            )
         else
             -- votedAndHidden: no frame to hide, just clean up state and promote
             PromoteFromQueue()
@@ -486,10 +549,14 @@ function ns.RollManager.CancelAllRolls()
 end
 
 function ns.RollManager.OnRollComplete(rollID)
-    if not rollID then return end
+    if not rollID then
+        return
+    end
 
     local roll = activeRolls[rollID]
-    if roll then roll.completing = true end
+    if roll then
+        roll.completing = true
+    end
 
     local completionToken = nil
     if roll then
@@ -503,9 +570,15 @@ function ns.RollManager.OnRollComplete(rollID)
     -- Delay cancel to keep activeRolls data available for async winner resolution
     LifecycleUtil.After(lifecycleState, ROLL_COMPLETE_CANCEL_DELAY, function()
         local activeRoll = activeRolls[rollID]
-        if not activeRoll then return end
-        if completionToken and activeRoll.completionToken ~= completionToken then return end
-        if not activeRoll.completing then return end
+        if not activeRoll then
+            return
+        end
+        if completionToken and activeRoll.completionToken ~= completionToken then
+            return
+        end
+        if not activeRoll.completing then
+            return
+        end
 
         ns.RollManager.CancelRoll(rollID)
     end)
@@ -533,7 +606,9 @@ end
 
 HideAfterVote = function(rollID)
     local roll = activeRolls[rollID]
-    if not roll or not roll.frameIndex then return end
+    if not roll or not roll.frameIndex then
+        return
+    end
 
     local frameIndex = roll.frameIndex
     roll.frameIndex = nil
@@ -546,21 +621,28 @@ HideAfterVote = function(rollID)
     end
 
     local token = LifecycleUtil.CaptureToken(lifecycleState)
-    ns.RollFrame.HideRoll(frameIndex, LifecycleUtil.Guard(lifecycleState, token, function()
-        ReleaseFrameIndex(frameIndex)
-        PromoteFromQueue()
-    end))
+    ns.RollFrame.HideRoll(
+        frameIndex,
+        LifecycleUtil.Guard(lifecycleState, token, function()
+            ReleaseFrameIndex(frameIndex)
+            PromoteFromQueue()
+        end)
+    )
 end
 
 function ns.RollManager.MarkPendingHide(rollID)
     local roll = activeRolls[rollID]
-    if not roll then return end
+    if not roll then
+        return
+    end
     roll.pendingHideAfterVote = true
 end
 
 function ns.RollManager.TryHideAfterVote(rollID)
     local roll = activeRolls[rollID]
-    if not roll or not roll.pendingHideAfterVote then return end
+    if not roll or not roll.pendingHideAfterVote then
+        return
+    end
     roll.pendingHideAfterVote = nil
     HideAfterVote(rollID)
 end

--- a/DragonLoot/Listeners/HistoryListener_Classic.lua
+++ b/DragonLoot/Listeners/HistoryListener_Classic.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: skip on Retail (Classic listener runs on everything else)
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
@@ -40,7 +42,9 @@ local notifiedRollResults = {}
 -------------------------------------------------------------------------------
 
 local function RefreshFromAPI()
-    if not C_LootHistory or not C_LootHistory.GetNumItems then return end
+    if not C_LootHistory or not C_LootHistory.GetNumItems then
+        return
+    end
     local numItems = C_LootHistory.GetNumItems()
     if not numItems or numItems == 0 then
         ns.HistoryFrame.SetEntries({})
@@ -50,8 +54,7 @@ local function RefreshFromAPI()
     local now = GetTime()
     local entries = {}
     for i = 1, numItems do
-        local _, itemLink, numPlayers, isDone, winnerIdx, _, _ =
-            C_LootHistory.GetItem(i)
+        local _, itemLink, numPlayers, isDone, winnerIdx, _, _ = C_LootHistory.GetItem(i)
 
         local winner, winnerClass, rollType, roll
         if winnerIdx and winnerIdx > 0 and numPlayers and numPlayers > 0 then
@@ -73,7 +76,9 @@ local function RefreshFromAPI()
                     }
                 end
             end
-            if #rollResults == 0 then rollResults = nil end
+            if #rollResults == 0 then
+                rollResults = nil
+            end
         end
 
         local quality = 1
@@ -105,17 +110,25 @@ end
 
 local function ProcessClassicRollResult(historyIndex, playerIndex)
     local rollID, itemLink = C_LootHistory.GetItem(historyIndex)
-    if not rollID or not itemLink then return end
+    if not rollID or not itemLink then
+        return
+    end
 
     local playerName, _, rollType, roll = C_LootHistory.GetPlayerInfo(historyIndex, playerIndex)
-    if not playerName then return end
+    if not playerName then
+        return
+    end
 
     -- Classic ROLL_CHANGED can fire before roll number is assigned
     -- For non-Pass rolls (rollType ~= 0), wait until roll value is available
-    if roll == nil and rollType and rollType ~= 0 then return end
+    if roll == nil and rollType and rollType ~= 0 then
+        return
+    end
 
     local dedupKey = rollID .. "-" .. playerName
-    if notifiedRollResults[dedupKey] then return end
+    if notifiedRollResults[dedupKey] then
+        return
+    end
     notifiedRollResults[dedupKey] = true
 
     -- Extract item info (may be cached from earlier GetItemInfo calls)
@@ -125,8 +138,14 @@ local function ProcessClassicRollResult(historyIndex, playerIndex)
     end
 
     ns.RollManager.SendRollResultNotification(
-        itemLink, itemName, itemQuality or 0, itemIcon or 0,
-        playerName, nil, rollType, roll
+        itemLink,
+        itemName,
+        itemQuality or 0,
+        itemIcon or 0,
+        playerName,
+        nil,
+        rollType,
+        roll
     )
 end
 

--- a/DragonLoot/Listeners/HistoryListener_Retail.lua
+++ b/DragonLoot/Listeners/HistoryListener_Retail.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: only run on Retail
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
@@ -41,7 +43,9 @@ local isInitializing = false
 -------------------------------------------------------------------------------
 
 local function GetItemQuality(itemLink)
-    if not itemLink then return 1 end
+    if not itemLink then
+        return 1
+    end
     local _, _, quality = GetItemInfo(itemLink)
     return quality or 1
 end
@@ -52,16 +56,18 @@ end
 -------------------------------------------------------------------------------
 
 local ROLL_STATE_MAP = {
-    [0] = 1,  -- NeedMainSpec -> Need
-    [1] = 1,  -- NeedOffSpec -> Need
-    [2] = 2,  -- Transmog -> Greed
-    [3] = 2,  -- Greed
-    [4] = 0,  -- NoRoll -> Pass
-    [5] = 0,  -- Pass
+    [0] = 1, -- NeedMainSpec -> Need
+    [1] = 1, -- NeedOffSpec -> Need
+    [2] = 2, -- Transmog -> Greed
+    [3] = 2, -- Greed
+    [4] = 0, -- NoRoll -> Pass
+    [5] = 0, -- Pass
 }
 
 local function ConvertRollState(state)
-    if state == nil then return nil end
+    if state == nil then
+        return nil
+    end
     return ROLL_STATE_MAP[state] or 0
 end
 
@@ -70,11 +76,17 @@ end
 -------------------------------------------------------------------------------
 
 local function ProcessRollResults(encounterID, drop)
-    if isInitializing then return end
-    if not drop or not drop.rollInfos then return end
+    if isInitializing then
+        return
+    end
+    if not drop or not drop.rollInfos then
+        return
+    end
 
     local stateMap = ns.NOTIFICATION_STATE_MAP
-    if not stateMap then return end
+    if not stateMap then
+        return
+    end
 
     local itemLink = drop.itemHyperlink
     local itemName = itemLink and itemLink:match("%[(.-)%]")
@@ -83,16 +95,24 @@ local function ProcessRollResults(encounterID, drop)
 
     for _, rollInfo in ipairs(drop.rollInfos) do
         if rollInfo.playerName and rollInfo.state then
-            local dedupKey = encounterID .. "-" .. drop.lootListID .. "-"
+            local dedupKey = encounterID
+                .. "-"
+                .. drop.lootListID
+                .. "-"
                 .. (rollInfo.playerGUID or rollInfo.playerName)
             if not notifiedRollResults[dedupKey] then
                 notifiedRollResults[dedupKey] = true
                 local rollType = stateMap[rollInfo.state]
                 local rollValue = rollInfo.roll
                 ns.RollManager.SendRollResultNotification(
-                    itemLink, itemName, itemQuality, itemIcon,
-                    rollInfo.playerName, rollInfo.playerClass,
-                    rollType, rollValue
+                    itemLink,
+                    itemName,
+                    itemQuality,
+                    itemIcon,
+                    rollInfo.playerName,
+                    rollInfo.playerClass,
+                    rollType,
+                    rollValue
                 )
             end
         end
@@ -104,10 +124,14 @@ end
 -------------------------------------------------------------------------------
 
 local function ProcessDrop(encounterID, drop)
-    if not drop then return end
+    if not drop then
+        return
+    end
 
     local itemLink = drop.itemHyperlink
-    if not itemLink then return end
+    if not itemLink then
+        return
+    end
 
     local dropKey = encounterID .. "-" .. drop.lootListID
 
@@ -128,7 +152,9 @@ local function ProcessDrop(encounterID, drop)
                 }
             end
         end
-        if #rollResults == 0 then rollResults = nil end
+        if #rollResults == 0 then
+            rollResults = nil
+        end
     end
 
     local entry = {
@@ -168,18 +194,21 @@ end
 -------------------------------------------------------------------------------
 
 local function OnHistoryUpdateEncounter(_, encounterID)
-    if not encounterID then return end
+    if not encounterID then
+        return
+    end
     -- Drops arrive individually via LOOT_HISTORY_UPDATE_DROP; just refresh display
     ns.HistoryFrame.Refresh()
     ns.DebugPrint("LOOT_HISTORY_UPDATE_ENCOUNTER: " .. tostring(encounterID))
 end
 
 local function OnHistoryUpdateDrop(_, encounterID, lootListID)
-    if not encounterID or not lootListID then return end
+    if not encounterID or not lootListID then
+        return
+    end
     local dropInfo = C_LootHistory.GetSortedInfoForDrop(encounterID, lootListID)
     ProcessDrop(encounterID, dropInfo)
-    ns.DebugPrint("LOOT_HISTORY_UPDATE_DROP: encounter="
-        .. tostring(encounterID) .. " drop=" .. tostring(lootListID))
+    ns.DebugPrint("LOOT_HISTORY_UPDATE_DROP: encounter=" .. tostring(encounterID) .. " drop=" .. tostring(lootListID))
 end
 
 local function OnHistoryClear()
@@ -194,9 +223,13 @@ end
 -------------------------------------------------------------------------------
 
 local function PopulateExistingHistory()
-    if not C_LootHistory.GetAllEncounterInfos then return end
+    if not C_LootHistory.GetAllEncounterInfos then
+        return
+    end
     local encounters = C_LootHistory.GetAllEncounterInfos()
-    if not encounters then return end
+    if not encounters then
+        return
+    end
     for _, encounter in ipairs(encounters) do
         local drops = C_LootHistory.GetSortedDropsForEncounter(encounter.encounterID)
         if drops then

--- a/DragonLoot/Listeners/ListenerShared.lua
+++ b/DragonLoot/Listeners/ListenerShared.lua
@@ -47,7 +47,9 @@ local lootHandleToRollID = {}
 -------------------------------------------------------------------------------
 
 function LS.GetItemTexture(itemLink)
-    if not itemLink then return nil end
+    if not itemLink then
+        return nil
+    end
     if GetItemInfoInstant then
         local _, _, _, _, icon = GetItemInfoInstant(itemLink)
         return icon
@@ -68,12 +70,16 @@ function LS.OnLootSlotCleared(isLootOpen, slotIndex)
 end
 
 function LS.OnLootSlotChanged(isLootOpen, slotIndex)
-    if not isLootOpen or not ns.LootFrame.UpdateSlot then return end
+    if not isLootOpen or not ns.LootFrame.UpdateSlot then
+        return
+    end
     ns.LootFrame.UpdateSlot(slotIndex)
 end
 
 function LS.OnLootClosed(isLootOpen, versionLabel)
-    if not isLootOpen then return false end
+    if not isLootOpen then
+        return false
+    end
 
     local ok, err = pcall(ns.LootFrame.Hide)
     if not ok then
@@ -91,20 +97,25 @@ end
 -------------------------------------------------------------------------------
 
 function LS.OnStartLootRoll(isRollActive, rollID, rollTime, msPerSec, _, lootHandle)
-    if not isRollActive then return end
+    if not isRollActive then
+        return
+    end
     if lootHandle then
         lootHandleToRollID[lootHandle] = rollID
     end
     local rollTimeSec = rollTime / msPerSec
     ns.RollManager.StartRoll(rollID, rollTimeSec)
-    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID)
-        .. " time=" .. tostring(rollTimeSec) .. "s")
+    ns.DebugPrint("START_LOOT_ROLL: rollID=" .. tostring(rollID) .. " time=" .. tostring(rollTimeSec) .. "s")
 end
 
 function LS.OnCancelLootRoll(isRollActive, rollID)
-    if not isRollActive then return end
+    if not isRollActive then
+        return
+    end
     local rolls = ns.RollManager.GetActiveRolls()
-    if rolls[rollID] and rolls[rollID].completing then return end
+    if rolls[rollID] and rolls[rollID].completing then
+        return
+    end
     for handle, id in pairs(lootHandleToRollID) do
         if id == rollID then
             lootHandleToRollID[handle] = nil
@@ -134,16 +145,19 @@ function LS.OnConfirmRoll(rollID, rollType)
 end
 
 function LS.OnLootRollsComplete(isRollActive, lootHandle)
-    if not isRollActive then return end
+    if not isRollActive then
+        return
+    end
     local rollID = lootHandleToRollID[lootHandle] or lootHandle
     lootHandleToRollID[lootHandle] = nil
     ns.RollManager.OnRollComplete(rollID)
-    ns.DebugPrint("LOOT_ROLLS_COMPLETE: handle=" .. tostring(lootHandle)
-        .. " rollID=" .. tostring(rollID))
+    ns.DebugPrint("LOOT_ROLLS_COMPLETE: handle=" .. tostring(lootHandle) .. " rollID=" .. tostring(rollID))
 end
 
 function LS.OnLootItemRollWon(isRollActive, itemLink, rollType, rollValue)
-    if not isRollActive then return end
+    if not isRollActive then
+        return
+    end
     ns.RollManager.OnLootItemRollWon(itemLink, rollType, rollValue)
 end
 
@@ -157,11 +171,17 @@ end
 function LS.ResolveWinner(getIsActive, lifecycleState, rollID, completionToken, resolveFromHistory)
     local LifecycleUtil = ns.LifecycleUtil
     LifecycleUtil.After(lifecycleState, LS.WINNER_RESOLVE_DELAY, function()
-        if not getIsActive() then return end
+        if not getIsActive() then
+            return
+        end
         local activeRolls = ns.RollManager.GetActiveRolls()
         local roll = activeRolls[rollID]
-        if not roll or not roll.completing then return end
-        if completionToken and roll.completionToken ~= completionToken then return end
+        if not roll or not roll.completing then
+            return
+        end
+        if completionToken and roll.completionToken ~= completionToken then
+            return
+        end
         resolveFromHistory(rollID)
     end)
 end

--- a/DragonLoot/Listeners/LootHistoryChat.lua
+++ b/DragonLoot/Listeners/LootHistoryChat.lua
@@ -58,7 +58,9 @@ local function EscapeLuaMagic(str)
 end
 
 local function BuildPattern(globalString)
-    if not globalString then return nil end
+    if not globalString then
+        return nil
+    end
     local pattern = EscapeLuaMagic(globalString)
     pattern = pattern:gsub("%%%%s", "(.+)")
     pattern = pattern:gsub("%%%%d", "(%%d+)")
@@ -124,10 +126,14 @@ local function ScheduleQualityRetry(entry, itemLink)
     local retryToken = entry.qualityRetryToken
 
     LifecycleUtil.After(lifecycleState, QUALITY_RETRY_DELAY, function()
-        if entry.qualityRetryToken ~= retryToken then return end
+        if entry.qualityRetryToken ~= retryToken then
+            return
+        end
 
         local _, _, quality = GetItemInfo(itemLink)
-        if not quality then return end
+        if not quality then
+            return
+        end
 
         entry.quality = quality
         entry.qualityRetryToken = nil
@@ -146,17 +152,23 @@ end
 
 local function AddLootEntry(playerName, playerClass, itemLink, _)
     local db = ns.Addon.db
-    if not db or not db.profile then return end
+    if not db or not db.profile then
+        return
+    end
 
     -- Config checks
-    if not db.profile.history.trackDirectLoot then return end
+    if not db.profile.history.trackDirectLoot then
+        return
+    end
 
     local icon = GetItemTexture(itemLink)
     local _, _, quality = GetItemInfo(itemLink)
 
     -- Quality filter (only for direct loot, rolled items are always tracked)
     local minQuality = db.profile.history.minQuality or 2
-    if quality and quality < minQuality then return end
+    if quality and quality < minQuality then
+        return
+    end
 
     local entry = {
         itemLink = itemLink,
@@ -259,7 +271,9 @@ local function ProcessLootMessage(message, _, guid)
         end
     end
 
-    if not itemLink then return end
+    if not itemLink then
+        return
+    end
 
     -- Dedup check
     CleanRecentEntries()

--- a/DragonLoot/Listeners/LootListener_Classic.lua
+++ b/DragonLoot/Listeners/LootListener_Classic.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: skip on Retail (Classic listener runs on everything else)
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- State
@@ -25,10 +27,14 @@ local isLootOpen = false
 -------------------------------------------------------------------------------
 
 local function OnLootOpened(_, autoLoot)
-    if isLootOpen then return end
+    if isLootOpen then
+        return
+    end
 
     local db = ns.Addon.db.profile
-    if not db.lootWindow.enabled then return end
+    if not db.lootWindow.enabled then
+        return
+    end
 
     isLootOpen = true
     ns.SuppressBlizzardLootFrame()

--- a/DragonLoot/Listeners/LootListener_Retail.lua
+++ b/DragonLoot/Listeners/LootListener_Retail.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: only run on Retail
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- State
@@ -42,10 +44,14 @@ local function OnLootOpened(_, autoLoot)
 end
 
 local function OnLootReady()
-    if isLootOpen then return end
+    if isLootOpen then
+        return
+    end
 
     local db = ns.Addon.db.profile
-    if not db.lootWindow.enabled then return end
+    if not db.lootWindow.enabled then
+        return
+    end
 
     isLootOpen = true
     ns.SuppressBlizzardLootFrame()

--- a/DragonLoot/Listeners/RollListener_Classic.lua
+++ b/DragonLoot/Listeners/RollListener_Classic.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: skip on Retail (Classic listener runs on everything else)
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
@@ -65,10 +67,14 @@ end
 -------------------------------------------------------------------------------
 
 local function RecoverActiveRolls()
-    if not GetActiveLootRollIDs then return end
+    if not GetActiveLootRollIDs then
+        return
+    end
 
     local activeRollIDs = GetActiveLootRollIDs()
-    if not activeRollIDs then return end
+    if not activeRollIDs then
+        return
+    end
     for _, rollID in ipairs(activeRollIDs) do
         local timeLeftMs = GetLootRollTimeLeft(rollID)
         if timeLeftMs and timeLeftMs > 0 then
@@ -87,10 +93,11 @@ local function ResolveWinnerFromHistory(rollID)
     local activeRolls = ns.RollManager.GetActiveRolls()
 
     local roll = activeRolls[rollID]
-    if not roll or not roll.itemName then return end
+    if not roll or not roll.itemName then
+        return
+    end
 
-    local numItems = C_LootHistory and C_LootHistory.GetNumItems
-        and C_LootHistory.GetNumItems() or 0
+    local numItems = C_LootHistory and C_LootHistory.GetNumItems and C_LootHistory.GetNumItems() or 0
     for i = numItems, 1, -1 do
         local _, itemName = C_LootHistory.GetItem(i)
         if itemName == roll.itemName then
@@ -143,6 +150,7 @@ function ns.RollListener.Shutdown()
 end
 
 function ns.RollListener.ResolveWinner(rollID, completionToken)
-    LS.ResolveWinner(function() return isRollActive end, lifecycleState, rollID, completionToken,
-        ResolveWinnerFromHistory)
+    LS.ResolveWinner(function()
+        return isRollActive
+    end, lifecycleState, rollID, completionToken, ResolveWinnerFromHistory)
 end

--- a/DragonLoot/Listeners/RollListener_Retail.lua
+++ b/DragonLoot/Listeners/RollListener_Retail.lua
@@ -11,7 +11,9 @@ local _, ns = ...
 -- Version guard: only run on Retail
 -------------------------------------------------------------------------------
 
-if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then
+    return
+end
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
@@ -49,7 +51,9 @@ local function OnCancelLootRoll(_, rollID)
 end
 
 local function OnCancelAllLootRolls()
-    if not isRollActive then return end
+    if not isRollActive then
+        return
+    end
 
     ns.RollManager.CancelAllRolls()
     ns.DebugPrint("CANCEL_ALL_LOOT_ROLLS")
@@ -72,10 +76,14 @@ end
 -------------------------------------------------------------------------------
 
 local function RecoverActiveRolls()
-    if not GetActiveLootRollIDs then return end
+    if not GetActiveLootRollIDs then
+        return
+    end
 
     local activeRollIDs = GetActiveLootRollIDs()
-    if not activeRollIDs then return end
+    if not activeRollIDs then
+        return
+    end
 
     local GetRollDuration = C_Loot and C_Loot.GetLootRollDuration
     for _, rollID in ipairs(activeRollIDs) do
@@ -99,11 +107,14 @@ local function ResolveWinnerFromHistory(rollID)
     local activeRolls = ns.RollManager.GetActiveRolls()
 
     local roll = activeRolls[rollID]
-    if not roll or not roll.itemLink then return end
+    if not roll or not roll.itemLink then
+        return
+    end
 
-    local encounters = C_LootHistory and C_LootHistory.GetAllEncounterInfos
-        and C_LootHistory.GetAllEncounterInfos()
-    if not encounters then return end
+    local encounters = C_LootHistory and C_LootHistory.GetAllEncounterInfos and C_LootHistory.GetAllEncounterInfos()
+    if not encounters then
+        return
+    end
 
     for i = #encounters, 1, -1 do
         local encounter = encounters[i]
@@ -166,6 +177,7 @@ function ns.RollListener.Shutdown()
 end
 
 function ns.RollListener.ResolveWinner(rollID, completionToken)
-    LS.ResolveWinner(function() return isRollActive end, lifecycleState, rollID, completionToken,
-        ResolveWinnerFromHistory)
+    LS.ResolveWinner(function()
+        return isRollActive
+    end, lifecycleState, rollID, completionToken, ResolveWinnerFromHistory)
 end

--- a/DragonLoot/Locales/deDE.lua
+++ b/DragonLoot/Locales/deDE.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "deDE")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -202,8 +202,9 @@ L["Show in Open World"] = true
 L["Show in Raids"] = true
 L["Show individual roll result notifications"] = true
 L["Hide After Voting"] = true
-L["Hide the roll frame after you cast your vote. The roll continues in the background" .. " and notifications still fire."] =
-    true
+-- stylua: ignore
+L["Hide the roll frame after you cast your vote. The roll continues in the background"
+    .. " and notifications still fire."] = true
 L["Show item name and bind type on the same line"] = true
 L["Show notifications for other group members' roll results"] = true
 L["Show notifications for your own roll results"] = true
@@ -252,14 +253,19 @@ L["Click history entries to expand and see all player rolls"] = true
 
 -- DragonLoot_Options/Tabs/AutoLootTab.lua
 L["Auto-Loot"] = true
-L["Automatically loot items that meet your criteria. Items on the whitelist are always" .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated" .. " against the minimum quality threshold."] =
-    true
+-- stylua: ignore
+L["Automatically loot items that meet your criteria."
+    .. " Items on the whitelist are always picked up."
+    .. " Items on the blacklist are never auto-looted."
+    .. " Everything else is evaluated against the minimum quality threshold."] = true
 L["Blacklist"] = true
 L["Enable Smart Auto-Loot"] = true
-L["Items on this list are always looted automatically, regardless of quality." .. " Drag an item from your bags onto an empty slot to add it."] =
-    true
-L["Items on this list are never auto-looted, even if they meet the quality threshold." .. " They will remain in the loot window for manual pickup."] =
-    true
+-- stylua: ignore
+L["Items on this list are always looted automatically, regardless of quality."
+    .. " Drag an item from your bags onto an empty slot to add it."] = true
+-- stylua: ignore
+L["Items on this list are never auto-looted, even if they meet the quality threshold."
+    .. " They will remain in the loot window for manual pickup."] = true
 L["No items - drag items here to add"] = true
 L["Smart Auto-Loot"] = true
 L["When enabled, qualifying items are automatically looted based on your filter rules"] = true
@@ -328,7 +334,9 @@ L["Delete Profile"] = true
 L["New Profile"] = true
 L["Profile Actions"] = true
 L["Profiles"] = true
-L["Profiles allow you to save different settings configurations. You can switch between" .. " profiles, copy settings from another profile, or reset to defaults."] =
-    true
+-- stylua: ignore
+L["Profiles allow you to save different settings configurations."
+    .. " You can switch between profiles, copy settings from another profile,"
+    .. " or reset to defaults."] = true
 L["Reset Current Profile"] = true
 L["Reset all settings in the current profile to their default values"] = true

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -6,7 +6,9 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "enUS", true, true)
-if not L then return end
+if not L then
+    return
+end
 
 -- Core/Init.lua
 L["Loaded. Type /dl help for commands."] = true
@@ -86,8 +88,8 @@ L["Center roll frame to horizontal center of screen"] = true
 L["Center Vertically"] = true
 L["Center roll frame to vertical center of screen"] = true
 L["Icon Position"] = true
-L["Icon position: Inside places the icon inside the frame."
-    .. " Outside places the icon outside the frame border."] = true
+L["Icon position: Inside places the icon inside the frame." .. " Outside places the icon outside the frame border."] =
+    true
 L["Icon Horizontal Offset"] = true
 L["Icon Outside Gap"] = true
 L["Icon Side"] = true
@@ -200,8 +202,8 @@ L["Show in Open World"] = true
 L["Show in Raids"] = true
 L["Show individual roll result notifications"] = true
 L["Hide After Voting"] = true
-L["Hide the roll frame after you cast your vote. The roll continues in the background"
-    .. " and notifications still fire."] = true
+L["Hide the roll frame after you cast your vote. The roll continues in the background" .. " and notifications still fire."] =
+    true
 L["Show item name and bind type on the same line"] = true
 L["Show notifications for other group members' roll results"] = true
 L["Show notifications for your own roll results"] = true
@@ -250,15 +252,14 @@ L["Click history entries to expand and see all player rolls"] = true
 
 -- DragonLoot_Options/Tabs/AutoLootTab.lua
 L["Auto-Loot"] = true
-L["Automatically loot items that meet your criteria. Items on the whitelist are always"
-    .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated"
-    .. " against the minimum quality threshold."] = true
+L["Automatically loot items that meet your criteria. Items on the whitelist are always" .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated" .. " against the minimum quality threshold."] =
+    true
 L["Blacklist"] = true
 L["Enable Smart Auto-Loot"] = true
-L["Items on this list are always looted automatically, regardless of quality."
-    .. " Drag an item from your bags onto an empty slot to add it."] = true
-L["Items on this list are never auto-looted, even if they meet the quality threshold."
-    .. " They will remain in the loot window for manual pickup."] = true
+L["Items on this list are always looted automatically, regardless of quality." .. " Drag an item from your bags onto an empty slot to add it."] =
+    true
+L["Items on this list are never auto-looted, even if they meet the quality threshold." .. " They will remain in the loot window for manual pickup."] =
+    true
 L["No items - drag items here to add"] = true
 L["Smart Auto-Loot"] = true
 L["When enabled, qualifying items are automatically looted based on your filter rules"] = true
@@ -317,7 +318,7 @@ L["Show Animation"] = true
 
 -- DragonLoot_Options/Tabs/ProfilesTab.lua
 L["Active Profile"] = true
-L["Are you sure you want to delete profile \"%s\"?"] = true
+L['Are you sure you want to delete profile "%s"?'] = true
 L["Are you sure you want to reset the current profile to defaults?"] = true
 L["Copy From"] = true
 L["Create"] = true
@@ -327,7 +328,7 @@ L["Delete Profile"] = true
 L["New Profile"] = true
 L["Profile Actions"] = true
 L["Profiles"] = true
-L["Profiles allow you to save different settings configurations. You can switch between"
-    .. " profiles, copy settings from another profile, or reset to defaults."] = true
+L["Profiles allow you to save different settings configurations. You can switch between" .. " profiles, copy settings from another profile, or reset to defaults."] =
+    true
 L["Reset Current Profile"] = true
 L["Reset all settings in the current profile to their default values"] = true

--- a/DragonLoot/Locales/esES.lua
+++ b/DragonLoot/Locales/esES.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "esES")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/esMX.lua
+++ b/DragonLoot/Locales/esMX.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "esMX")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/frFR.lua
+++ b/DragonLoot/Locales/frFR.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "frFR")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/itIT.lua
+++ b/DragonLoot/Locales/itIT.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "itIT")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/koKR.lua
+++ b/DragonLoot/Locales/koKR.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "koKR")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/ptBR.lua
+++ b/DragonLoot/Locales/ptBR.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "ptBR")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/ruRU.lua
+++ b/DragonLoot/Locales/ruRU.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "ruRU")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/zhCN.lua
+++ b/DragonLoot/Locales/zhCN.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "zhCN")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot/Locales/zhTW.lua
+++ b/DragonLoot/Locales/zhTW.lua
@@ -6,6 +6,8 @@
 -------------------------------------------------------------------------------
 local ADDON_NAME, _ = ... -- luacheck: ignore 211/ns
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "zhTW")
-if not L then return end
+if not L then
+    return
+end
 
 -- Translations go here

--- a/DragonLoot_Options/Core.lua
+++ b/DragonLoot_Options/Core.lua
@@ -55,10 +55,18 @@ ns.QualityValues = {
 
 DW.On("OnAppearanceChanged", function()
     local dl = ns.dlns
-    if not dl then return end
-    if dl.LootFrame and dl.LootFrame.ApplySettings then dl.LootFrame.ApplySettings() end
-    if dl.RollManager and dl.RollManager.ApplySettings then dl.RollManager.ApplySettings() end
-    if dl.HistoryFrame and dl.HistoryFrame.ApplySettings then dl.HistoryFrame.ApplySettings() end
+    if not dl then
+        return
+    end
+    if dl.LootFrame and dl.LootFrame.ApplySettings then
+        dl.LootFrame.ApplySettings()
+    end
+    if dl.RollManager and dl.RollManager.ApplySettings then
+        dl.RollManager.ApplySettings()
+    end
+    if dl.HistoryFrame and dl.HistoryFrame.ApplySettings then
+        dl.HistoryFrame.ApplySettings()
+    end
 end)
 
 -------------------------------------------------------------------------------
@@ -102,12 +110,16 @@ function DragonLoot_Options.Open()
     if not panelResult then
         CreateOptionsPanel()
     end
-    if not panelResult then return end
+    if not panelResult then
+        return
+    end
     panelResult.Open()
 end
 
 function DragonLoot_Options.Close()
-    if not panelResult then return end
+    if not panelResult then
+        return
+    end
     panelResult.Close()
 end
 
@@ -115,6 +127,8 @@ function DragonLoot_Options.Toggle()
     if not panelResult then
         CreateOptionsPanel()
     end
-    if not panelResult then return end
+    if not panelResult then
+        return
+    end
     panelResult.Toggle()
 end

--- a/DragonLoot_Options/Tabs/AnimationTab.lua
+++ b/DragonLoot_Options/Tabs/AnimationTab.lua
@@ -20,7 +20,7 @@ local LibStub = LibStub
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -35,7 +35,9 @@ local dlns
 
 local function GetEntranceValues()
     local lib = LibStub("LibAnimate", true)
-    if not lib then return {} end
+    if not lib then
+        return {}
+    end
     local names = lib:GetEntranceAnimations()
     local values = { { value = "none", text = L["None"] } }
     for _, name in ipairs(names) do
@@ -46,7 +48,9 @@ end
 
 local function GetExitValues()
     local lib = LibStub("LibAnimate", true)
-    if not lib then return {} end
+    if not lib then
+        return {}
+    end
     local names = lib:GetExitAnimations()
     local values = { { value = "none", text = L["None"] } }
     for _, name in ipairs(names) do
@@ -63,7 +67,9 @@ local function CreateAnimDropdown(content, db, innerY, label, key, valuesFn)
     local dropdown = W.CreateDropdown(content, {
         label = label,
         values = valuesFn,
-        get = function() return db.profile.animation[key] end,
+        get = function()
+            return db.profile.animation[key]
+        end,
         set = function(value)
             db.profile.animation[key] = value
             LC.NotifyAppearanceChange()
@@ -91,7 +97,9 @@ local function CreateContent(parent)
     local enableToggle = W.CreateToggle(animContent, {
         label = L["Enable Animations"],
         tooltip = L["Enable or disable all DragonLoot animations"],
-        get = function() return db.profile.animation.enabled end,
+        get = function()
+            return db.profile.animation.enabled
+        end,
         set = function(value)
             db.profile.animation.enabled = value
             LC.NotifyAppearanceChange()
@@ -106,7 +114,9 @@ local function CreateContent(parent)
         max = 1,
         step = 0.05,
         format = "%.2f",
-        get = function() return db.profile.animation.openDuration end,
+        get = function()
+            return db.profile.animation.openDuration
+        end,
         set = function(value)
             db.profile.animation.openDuration = value
             LC.NotifyAppearanceChange()
@@ -121,7 +131,9 @@ local function CreateContent(parent)
         max = 1,
         step = 0.05,
         format = "%.2f",
-        get = function() return db.profile.animation.closeDuration end,
+        get = function()
+            return db.profile.animation.closeDuration
+        end,
         set = function(value)
             db.profile.animation.closeDuration = value
             LC.NotifyAppearanceChange()
@@ -139,12 +151,8 @@ local function CreateContent(parent)
     local lootContent = lootSection.content
     local lootY = -LC.SECTION_PADDING_TOP
 
-    lootY = CreateAnimDropdown(
-        lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues
-    )
-    lootY = CreateAnimDropdown(
-        lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues
-    )
+    lootY = CreateAnimDropdown(lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues)
+    lootY = CreateAnimDropdown(lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues)
 
     lootSection:SetContentHeight(math_abs(lootY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(lootSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
@@ -156,12 +164,8 @@ local function CreateContent(parent)
     local rollContent = rollSection.content
     local rollY = -LC.SECTION_PADDING_TOP
 
-    rollY = CreateAnimDropdown(
-        rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues
-    )
-    rollY = CreateAnimDropdown(
-        rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues
-    )
+    rollY = CreateAnimDropdown(rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues)
+    rollY = CreateAnimDropdown(rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues)
 
     rollSection:SetContentHeight(math_abs(rollY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(rollSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS

--- a/DragonLoot_Options/Tabs/AppearanceTab.lua
+++ b/DragonLoot_Options/Tabs/AppearanceTab.lua
@@ -18,7 +18,7 @@ local math_abs = math.abs
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -79,7 +79,9 @@ local function CreateFontSection(parent, db, yOffset)
         values = GetFontValues,
         sort = true,
         mediaType = "font",
-        get = function() return db.profile.appearance.font end,
+        get = function()
+            return db.profile.appearance.font
+        end,
         set = function(value)
             db.profile.appearance.font = value
             LC.NotifyAppearanceChange()
@@ -94,7 +96,9 @@ local function CreateFontSection(parent, db, yOffset)
         max = 20,
         step = 1,
         format = "%d",
-        get = function() return db.profile.appearance.fontSize end,
+        get = function()
+            return db.profile.appearance.fontSize
+        end,
         set = function(value)
             db.profile.appearance.fontSize = value
             LC.NotifyAppearanceChange()
@@ -105,7 +109,9 @@ local function CreateFontSection(parent, db, yOffset)
     local outlineDropdown = W.CreateDropdown(content, {
         label = L["Font Outline"],
         values = FONT_OUTLINE_VALUES,
-        get = function() return db.profile.appearance.fontOutline end,
+        get = function()
+            return db.profile.appearance.fontOutline
+        end,
         set = function(value)
             db.profile.appearance.fontOutline = value
             LC.NotifyAppearanceChange()
@@ -116,7 +122,9 @@ local function CreateFontSection(parent, db, yOffset)
     local fontShadowToggle = W.CreateToggle(content, {
         label = L["Text Shadow"],
         tooltip = L["Enable text shadow on all text elements"],
-        get = function() return db.profile.appearance.fontShadow end,
+        get = function()
+            return db.profile.appearance.fontShadow
+        end,
         set = function(value)
             db.profile.appearance.fontShadow = value
             LC.NotifyAppearanceChange()
@@ -146,7 +154,9 @@ local function CreateIconSection(parent, db, yOffset)
         max = 64,
         step = 2,
         format = "%d",
-        get = function() return db.profile.appearance.lootIconSize end,
+        get = function()
+            return db.profile.appearance.lootIconSize
+        end,
         set = function(value)
             db.profile.appearance.lootIconSize = value
             LC.NotifyAppearanceChange()
@@ -161,7 +171,9 @@ local function CreateIconSection(parent, db, yOffset)
         max = 64,
         step = 2,
         format = "%d",
-        get = function() return db.profile.appearance.rollIconSize end,
+        get = function()
+            return db.profile.appearance.rollIconSize
+        end,
         set = function(value)
             db.profile.appearance.rollIconSize = value
             LC.NotifyAppearanceChange()
@@ -176,7 +188,9 @@ local function CreateIconSection(parent, db, yOffset)
         max = 48,
         step = 2,
         format = "%d",
-        get = function() return db.profile.appearance.historyIconSize end,
+        get = function()
+            return db.profile.appearance.historyIconSize
+        end,
         set = function(value)
             db.profile.appearance.historyIconSize = value
             LC.NotifyAppearanceChange()
@@ -187,7 +201,9 @@ local function CreateIconSection(parent, db, yOffset)
     local qualityBorderToggle = W.CreateToggle(content, {
         label = L["Quality Border"],
         tooltip = L["Show quality-colored borders on item icons"],
-        get = function() return db.profile.appearance.qualityBorder end,
+        get = function()
+            return db.profile.appearance.qualityBorder
+        end,
         set = function(value)
             db.profile.appearance.qualityBorder = value
             LC.NotifyAppearanceChange()
@@ -198,7 +214,9 @@ local function CreateIconSection(parent, db, yOffset)
     local itemLevelToggle = W.CreateToggle(content, {
         label = L["Show Item Level"],
         tooltip = L["Show item level overlay on roll frame icon"],
-        get = function() return db.profile.appearance.showItemLevel end,
+        get = function()
+            return db.profile.appearance.showItemLevel
+        end,
         set = function(value)
             db.profile.appearance.showItemLevel = value
             LC.NotifyAppearanceChange()
@@ -209,7 +227,9 @@ local function CreateIconSection(parent, db, yOffset)
     local slotBgDropdown = W.CreateDropdown(content, {
         label = L["Slot Background"],
         values = SLOT_BG_VALUES,
-        get = function() return db.profile.appearance.slotBackground end,
+        get = function()
+            return db.profile.appearance.slotBackground
+        end,
         set = function(value)
             db.profile.appearance.slotBackground = value
             LC.NotifyAppearanceChange()
@@ -255,7 +275,9 @@ local function CreateBackgroundSection(parent, db, yOffset)
         max = 1,
         step = 0.05,
         isPercent = true,
-        get = function() return db.profile.appearance.backgroundAlpha end,
+        get = function()
+            return db.profile.appearance.backgroundAlpha
+        end,
         set = function(value)
             db.profile.appearance.backgroundAlpha = value
             LC.NotifyAppearanceChange()
@@ -268,7 +290,9 @@ local function CreateBackgroundSection(parent, db, yOffset)
         values = GetBackgroundValues,
         sort = true,
         mediaType = "background",
-        get = function() return db.profile.appearance.backgroundTexture end,
+        get = function()
+            return db.profile.appearance.backgroundTexture
+        end,
         set = function(value)
             db.profile.appearance.backgroundTexture = value
             LC.NotifyAppearanceChange()
@@ -314,7 +338,9 @@ local function CreateBorderSection(parent, db, yOffset)
         max = 4,
         step = 1,
         format = "%d",
-        get = function() return db.profile.appearance.borderSize end,
+        get = function()
+            return db.profile.appearance.borderSize
+        end,
         set = function(value)
             db.profile.appearance.borderSize = value
             LC.NotifyAppearanceChange()
@@ -327,7 +353,9 @@ local function CreateBorderSection(parent, db, yOffset)
         values = GetBorderValues,
         sort = true,
         mediaType = "border",
-        get = function() return db.profile.appearance.borderTexture end,
+        get = function()
+            return db.profile.appearance.borderTexture
+        end,
         set = function(value)
             db.profile.appearance.borderTexture = value
             LC.NotifyAppearanceChange()

--- a/DragonLoot_Options/Tabs/AutoLootTab.lua
+++ b/DragonLoot_Options/Tabs/AutoLootTab.lua
@@ -44,9 +44,13 @@ local function CreateSettingsSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
+    -- stylua: ignore
     local desc = W.CreateDescription(
         content,
-        L["Automatically loot items that meet your criteria. Items on the whitelist are always" .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated" .. " against the minimum quality threshold."]
+        L["Automatically loot items that meet your criteria."
+            .. " Items on the whitelist are always picked up."
+            .. " Items on the blacklist are never auto-looted."
+            .. " Everything else is evaluated against the minimum quality threshold."]
     )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
@@ -89,9 +93,11 @@ local function CreateWhitelistSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
+    -- stylua: ignore
     local desc = W.CreateDescription(
         content,
-        L["Items on this list are always looted automatically, regardless of quality." .. " Drag an item from your bags onto an empty slot to add it."]
+        L["Items on this list are always looted automatically, regardless of quality."
+            .. " Drag an item from your bags onto an empty slot to add it."]
     )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
@@ -123,9 +129,11 @@ local function CreateBlacklistSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
+    -- stylua: ignore
     local desc = W.CreateDescription(
         content,
-        L["Items on this list are never auto-looted, even if they meet the quality threshold." .. " They will remain in the loot window for manual pickup."]
+        L["Items on this list are never auto-looted, even if they meet the quality threshold."
+            .. " They will remain in the loot window for manual pickup."]
     )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 

--- a/DragonLoot_Options/Tabs/AutoLootTab.lua
+++ b/DragonLoot_Options/Tabs/AutoLootTab.lua
@@ -20,7 +20,7 @@ local tonumber = tonumber
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -44,25 +44,33 @@ local function CreateSettingsSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
-    local desc = W.CreateDescription(content,
-        L["Automatically loot items that meet your criteria. Items on the whitelist are always"
-        .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated"
-        .. " against the minimum quality threshold."])
+    local desc = W.CreateDescription(
+        content,
+        L["Automatically loot items that meet your criteria. Items on the whitelist are always" .. " picked up. Items on the blacklist are never auto-looted. Everything else is evaluated" .. " against the minimum quality threshold."]
+    )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local enableToggle = W.CreateToggle(content, {
         label = L["Enable Smart Auto-Loot"],
         tooltip = L["When enabled, qualifying items are automatically looted based on your filter rules"],
-        get = function() return db.profile.autoLoot.enabled end,
-        set = function(value) db.profile.autoLoot.enabled = value end,
+        get = function()
+            return db.profile.autoLoot.enabled
+        end,
+        set = function(value)
+            db.profile.autoLoot.enabled = value
+        end,
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local qualityDropdown = W.CreateDropdown(content, {
         label = L["Minimum Quality"],
         values = ns.QualityValues,
-        get = function() return tostring(db.profile.autoLoot.minQuality) end,
-        set = function(value) db.profile.autoLoot.minQuality = tonumber(value) or 0 end,
+        get = function()
+            return tostring(db.profile.autoLoot.minQuality)
+        end,
+        set = function(value)
+            db.profile.autoLoot.minQuality = tonumber(value) or 0
+        end,
     })
     innerY = LC.AnchorWidget(qualityDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
@@ -81,15 +89,20 @@ local function CreateWhitelistSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
-    local desc = W.CreateDescription(content,
-        L["Items on this list are always looted automatically, regardless of quality."
-        .. " Drag an item from your bags onto an empty slot to add it."])
+    local desc = W.CreateDescription(
+        content,
+        L["Items on this list are always looted automatically, regardless of quality." .. " Drag an item from your bags onto an empty slot to add it."]
+    )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local itemList = W.CreateItemList(content, {
         label = "",
-        getItems = function() return db.profile.autoLoot.whitelist end,
-        setItems = function(t) db.profile.autoLoot.whitelist = t end,
+        getItems = function()
+            return db.profile.autoLoot.whitelist
+        end,
+        setItems = function(t)
+            db.profile.autoLoot.whitelist = t
+        end,
         emptyText = L["No items - drag items here to add"],
     })
     itemList:SetHeight(ITEM_LIST_HEIGHT)
@@ -110,15 +123,20 @@ local function CreateBlacklistSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
-    local desc = W.CreateDescription(content,
-        L["Items on this list are never auto-looted, even if they meet the quality threshold."
-        .. " They will remain in the loot window for manual pickup."])
+    local desc = W.CreateDescription(
+        content,
+        L["Items on this list are never auto-looted, even if they meet the quality threshold." .. " They will remain in the loot window for manual pickup."]
+    )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local itemList = W.CreateItemList(content, {
         label = "",
-        getItems = function() return db.profile.autoLoot.blacklist end,
-        setItems = function(t) db.profile.autoLoot.blacklist = t end,
+        getItems = function()
+            return db.profile.autoLoot.blacklist
+        end,
+        setItems = function(t)
+            db.profile.autoLoot.blacklist = t
+        end,
         emptyText = L["No items - drag items here to add"],
     })
     itemList:SetHeight(ITEM_LIST_HEIGHT)

--- a/DragonLoot_Options/Tabs/GeneralTab.lua
+++ b/DragonLoot_Options/Tabs/GeneralTab.lua
@@ -18,7 +18,7 @@ local math_abs = math.abs
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -47,7 +47,9 @@ local function CreateContent(parent)
     local enableToggle = W.CreateToggle(content, {
         label = L["Enable DragonLoot"],
         tooltip = L["Enable or disable the DragonLoot addon"],
-        get = function() return db.profile.enabled end,
+        get = function()
+            return db.profile.enabled
+        end,
         set = function(value)
             db.profile.enabled = value
             if value then
@@ -63,7 +65,9 @@ local function CreateContent(parent)
     local minimapToggle = W.CreateToggle(content, {
         label = L["Show Minimap Icon"],
         tooltip = L["Show or hide the minimap button"],
-        get = function() return not db.profile.minimap.hide end,
+        get = function()
+            return not db.profile.minimap.hide
+        end,
         set = function(value)
             db.profile.minimap.hide = not value
             if dlns.MinimapIcon and dlns.MinimapIcon.Refresh then
@@ -77,7 +81,9 @@ local function CreateContent(parent)
     local debugToggle = W.CreateToggle(content, {
         label = L["Debug Mode"],
         tooltip = L["Enable verbose debug output in chat"],
-        get = function() return db.profile.debug end,
+        get = function()
+            return db.profile.debug
+        end,
         set = function(value)
             db.profile.debug = value
         end,

--- a/DragonLoot_Options/Tabs/HistoryTab.lua
+++ b/DragonLoot_Options/Tabs/HistoryTab.lua
@@ -20,7 +20,7 @@ local tonumber = tonumber
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -51,7 +51,9 @@ local function CreateTogglesSection(parent, db, yOffset)
     -- Enable History
     local enableToggle = W.CreateToggle(content, {
         label = L["Enable History"],
-        get = function() return db.profile.history.enabled end,
+        get = function()
+            return db.profile.history.enabled
+        end,
         set = function(value)
             db.profile.history.enabled = value
             ApplyHistorySettings()
@@ -62,7 +64,9 @@ local function CreateTogglesSection(parent, db, yOffset)
     -- Auto Show on Loot
     local autoShowToggle = W.CreateToggle(content, {
         label = L["Auto Show on Loot"],
-        get = function() return db.profile.history.autoShow end,
+        get = function()
+            return db.profile.history.autoShow
+        end,
         set = function(value)
             db.profile.history.autoShow = value
         end,
@@ -76,7 +80,9 @@ local function CreateTogglesSection(parent, db, yOffset)
     local trackToggle = W.CreateToggle(content, {
         label = L["Track Direct Loot"],
         tooltip = L["Track items you pick up directly (not from a loot window)"],
-        get = function() return db.profile.history.trackDirectLoot end,
+        get = function()
+            return db.profile.history.trackDirectLoot
+        end,
         set = function(value)
             db.profile.history.trackDirectLoot = value
             if qualityDropdown then
@@ -90,7 +96,9 @@ local function CreateTogglesSection(parent, db, yOffset)
     qualityDropdown = W.CreateDropdown(content, {
         label = L["Minimum Quality"],
         values = ns.QualityValues,
-        get = function() return tostring(db.profile.history.minQuality) end,
+        get = function()
+            return tostring(db.profile.history.minQuality)
+        end,
         set = function(value)
             db.profile.history.minQuality = tonumber(value) or 0
         end,
@@ -108,7 +116,9 @@ local function CreateTogglesSection(parent, db, yOffset)
     local rollDetailsToggle = W.CreateToggle(content, {
         label = L["Show Roll Details"],
         tooltip = L["Click history entries to expand and see all player rolls"],
-        get = function() return db.profile.history.showRollDetails end,
+        get = function()
+            return db.profile.history.showRollDetails
+        end,
         set = function(value)
             db.profile.history.showRollDetails = value
             ApplyHistorySettings()
@@ -134,9 +144,13 @@ local function CreateLayoutSection(parent, db, yOffset)
     -- Slider: Max Entries
     local maxEntriesSlider = W.CreateSlider(content, {
         label = L["Max Entries"],
-        min = 10, max = 500, step = 10,
+        min = 10,
+        max = 500,
+        step = 10,
         format = "%d",
-        get = function() return db.profile.history.maxEntries end,
+        get = function()
+            return db.profile.history.maxEntries
+        end,
         set = function(value)
             db.profile.history.maxEntries = value
         end,
@@ -146,9 +160,13 @@ local function CreateLayoutSection(parent, db, yOffset)
     -- Slider: Entry Spacing
     local entrySpacingSlider = W.CreateSlider(content, {
         label = L["Entry Spacing"],
-        min = 0, max = 12, step = 1,
+        min = 0,
+        max = 12,
+        step = 1,
         format = "%d",
-        get = function() return db.profile.history.entrySpacing end,
+        get = function()
+            return db.profile.history.entrySpacing
+        end,
         set = function(value)
             db.profile.history.entrySpacing = value
             ApplyHistorySettings()
@@ -159,9 +177,13 @@ local function CreateLayoutSection(parent, db, yOffset)
     -- Slider: Content Padding
     local contentPaddingSlider = W.CreateSlider(content, {
         label = L["Content Padding"],
-        min = 0, max = 12, step = 1,
+        min = 0,
+        max = 12,
+        step = 1,
         format = "%d",
-        get = function() return db.profile.history.contentPadding end,
+        get = function()
+            return db.profile.history.contentPadding
+        end,
         set = function(value)
             db.profile.history.contentPadding = value
             ApplyHistorySettings()

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -97,7 +97,9 @@ local function CreateRollFrameSection(parent, db, yOffset)
 
     local hideOnVoteToggle = W.CreateToggle(content, {
         label = L["Hide After Voting"],
-        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background" .. " and notifications still fire."],
+        -- stylua: ignore
+        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background"
+            .. " and notifications still fire."],
         get = function()
             return db.profile.rollFrame.hideOnVote
         end,
@@ -395,7 +397,9 @@ local function CreateLayoutSection(parent, db, yOffset)
 
     local iconPositionDropdown = W.CreateDropdown(content, {
         label = L["Icon Position"],
-        tooltip = L["Icon position: Inside places the icon inside the frame." .. " Outside places the icon outside the frame border."],
+        -- stylua: ignore
+        tooltip = L["Icon position: Inside places the icon inside the frame."
+            .. " Outside places the icon outside the frame border."],
         values = ICON_POSITION_VALUES,
         get = function()
             return db.profile.rollFrame.iconPosition

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -18,7 +18,7 @@ local math_abs = math.abs
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ local ICON_POSITION_VALUES = {
 }
 
 local ICON_SIDE_VALUES = {
-    { value = "left",  text = L["Left"] },
+    { value = "left", text = L["Left"] },
     { value = "right", text = L["Right"] },
 }
 
@@ -73,7 +73,9 @@ local function CreateRollFrameSection(parent, db, yOffset)
     local enableToggle = W.CreateToggle(content, {
         label = L["Enable Custom Roll Frame"],
         tooltip = L["Replace the default Blizzard roll frame with DragonLoot's custom version"],
-        get = function() return db.profile.rollFrame.enabled end,
+        get = function()
+            return db.profile.rollFrame.enabled
+        end,
         set = function(value)
             db.profile.rollFrame.enabled = value
             NotifyRollManager()
@@ -84,17 +86,24 @@ local function CreateRollFrameSection(parent, db, yOffset)
     local lockToggle = W.CreateToggle(content, {
         label = L["Lock Position"],
         tooltip = L["Prevent the roll frame from being dragged"],
-        get = function() return db.profile.rollFrame.lock end,
-        set = function(value) db.profile.rollFrame.lock = value end,
+        get = function()
+            return db.profile.rollFrame.lock
+        end,
+        set = function(value)
+            db.profile.rollFrame.lock = value
+        end,
     })
     innerY = LC.AnchorWidget(lockToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local hideOnVoteToggle = W.CreateToggle(content, {
         label = L["Hide After Voting"],
-        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background"
-            .. " and notifications still fire."],
-        get = function() return db.profile.rollFrame.hideOnVote end,
-        set = function(value) db.profile.rollFrame.hideOnVote = value end,
+        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background" .. " and notifications still fire."],
+        get = function()
+            return db.profile.rollFrame.hideOnVote
+        end,
+        set = function(value)
+            db.profile.rollFrame.hideOnVote = value
+        end,
     })
     innerY = LC.AnchorWidget(hideOnVoteToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
@@ -168,7 +177,9 @@ local function CreateLayoutSlider(content, db, innerY, label, tooltip, key, min,
         max = max,
         step = step,
         format = fmt,
-        get = function() return db.profile.rollFrame[key] end,
+        get = function()
+            return db.profile.rollFrame[key]
+        end,
         set = function(value)
             db.profile.rollFrame[key] = value
             NotifyRollManager()
@@ -187,7 +198,7 @@ local function CreateLayoutSection(parent, db, yOffset)
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
-    local frameMinHeightSlider, rowSpacingSlider  -- forward declare for compact toggle
+    local frameMinHeightSlider, rowSpacingSlider -- forward declare for compact toggle
 
     local isCompact = db.profile.rollFrame.compactTextLayout
 
@@ -198,7 +209,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         max = 120,
         step = 1,
         format = "%d",
-        get = function() return db.profile.rollFrame.frameMinHeight end,
+        get = function()
+            return db.profile.rollFrame.frameMinHeight
+        end,
         set = function(value)
             db.profile.rollFrame.frameMinHeight = value
             NotifyRollManager()
@@ -207,10 +220,19 @@ local function CreateLayoutSection(parent, db, yOffset)
     frameMinHeightSlider:SetDisabled(isCompact)
     innerY = LC.AnchorWidget(frameMinHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f")
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Frame Width"], L["Width of the roll frame"], "frameWidth", 200, 500, 10, "%d")
+    innerY = CreateLayoutSlider(content, db, innerY, L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f")
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Frame Width"],
+        L["Width of the roll frame"],
+        "frameWidth",
+        200,
+        500,
+        10,
+        "%d"
+    )
 
     rowSpacingSlider = W.CreateSlider(content, {
         label = L["Row Spacing"],
@@ -219,7 +241,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         max = 16,
         step = 1,
         format = "%d",
-        get = function() return db.profile.rollFrame.rowSpacing end,
+        get = function()
+            return db.profile.rollFrame.rowSpacing
+        end,
         set = function(value)
             db.profile.rollFrame.rowSpacing = value
             NotifyRollManager()
@@ -229,17 +253,23 @@ local function CreateLayoutSection(parent, db, yOffset)
     innerY = LC.AnchorWidget(rowSpacingSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Timer Bar Style dropdown + height sliders
-    local timerBarHeightSlider, minimalHeightSlider  -- forward declare
+    local timerBarHeightSlider, minimalHeightSlider -- forward declare
 
     local styleDropdown = W.CreateDropdown(content, {
         label = L["Timer Bar Style"],
         values = TIMER_BAR_STYLE_VALUES,
-        get = function() return db.profile.rollFrame.timerBarStyle end,
+        get = function()
+            return db.profile.rollFrame.timerBarStyle
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarStyle = value
             local isMinimal = (value == "minimal")
-            if timerBarHeightSlider then timerBarHeightSlider:SetDisabled(isMinimal) end
-            if minimalHeightSlider then minimalHeightSlider:SetDisabled(not isMinimal) end
+            if timerBarHeightSlider then
+                timerBarHeightSlider:SetDisabled(isMinimal)
+            end
+            if minimalHeightSlider then
+                minimalHeightSlider:SetDisabled(not isMinimal)
+            end
             NotifyRollManager()
         end,
     })
@@ -252,7 +282,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         max = 24,
         step = 1,
         format = "%d",
-        get = function() return db.profile.rollFrame.timerBarHeight end,
+        get = function()
+            return db.profile.rollFrame.timerBarHeight
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarHeight = value
             NotifyRollManager()
@@ -268,7 +300,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         max = 6,
         step = 1,
         format = "%d",
-        get = function() return db.profile.rollFrame.timerBarMinimalHeight end,
+        get = function()
+            return db.profile.rollFrame.timerBarMinimalHeight
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarMinimalHeight = value
             NotifyRollManager()
@@ -277,43 +311,95 @@ local function CreateLayoutSection(parent, db, yOffset)
     minimalHeightSlider:SetDisabled(db.profile.rollFrame.timerBarStyle ~= "minimal")
     innerY = LC.AnchorWidget(minimalHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Timer Bar Spacing"], L["Space between item row and timer bar"],
-        "timerBarSpacing", 0, 16, 1, "%d")
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Content Padding"], L["Inner padding of the roll frame"],
-        "contentPadding", 0, 12, 1, "%d")
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Button Size"], L["Size of Need/Greed/Pass buttons"],
-        "buttonSize", 16, 36, 1, "%d")
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Button Spacing"], L["Spacing between roll buttons"],
-        "buttonSpacing", 0, 12, 1, "%d")
-    innerY = CreateLayoutSlider(content, db, innerY,
-        L["Frame Spacing"], L["Spacing between multiple roll frames"],
-        "frameSpacing", 0, 16, 1, "%d")
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Timer Bar Spacing"],
+        L["Space between item row and timer bar"],
+        "timerBarSpacing",
+        0,
+        16,
+        1,
+        "%d"
+    )
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Content Padding"],
+        L["Inner padding of the roll frame"],
+        "contentPadding",
+        0,
+        12,
+        1,
+        "%d"
+    )
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Button Size"],
+        L["Size of Need/Greed/Pass buttons"],
+        "buttonSize",
+        16,
+        36,
+        1,
+        "%d"
+    )
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Button Spacing"],
+        L["Spacing between roll buttons"],
+        "buttonSpacing",
+        0,
+        12,
+        1,
+        "%d"
+    )
+    innerY = CreateLayoutSlider(
+        content,
+        db,
+        innerY,
+        L["Frame Spacing"],
+        L["Spacing between multiple roll frames"],
+        "frameSpacing",
+        0,
+        16,
+        1,
+        "%d"
+    )
 
     local compactToggle = W.CreateToggle(content, {
         label = L["Compact Text Layout"],
         tooltip = L["Show item name and bind type on the same line"],
-        get = function() return db.profile.rollFrame.compactTextLayout end,
+        get = function()
+            return db.profile.rollFrame.compactTextLayout
+        end,
         set = function(value)
             db.profile.rollFrame.compactTextLayout = value
-            if frameMinHeightSlider then frameMinHeightSlider:SetDisabled(value) end
-            if rowSpacingSlider then rowSpacingSlider:SetDisabled(value) end
+            if frameMinHeightSlider then
+                frameMinHeightSlider:SetDisabled(value)
+            end
+            if rowSpacingSlider then
+                rowSpacingSlider:SetDisabled(value)
+            end
             NotifyRollManager()
         end,
     })
     innerY = LC.AnchorWidget(compactToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local iconOutsideGapSlider  -- forward declared; assigned below
+    local iconOutsideGapSlider -- forward declared; assigned below
 
     local iconPositionDropdown = W.CreateDropdown(content, {
         label = L["Icon Position"],
-        tooltip = L["Icon position: Inside places the icon inside the frame."
-            .. " Outside places the icon outside the frame border."],
+        tooltip = L["Icon position: Inside places the icon inside the frame." .. " Outside places the icon outside the frame border."],
         values = ICON_POSITION_VALUES,
-        get = function() return db.profile.rollFrame.iconPosition end,
+        get = function()
+            return db.profile.rollFrame.iconPosition
+        end,
         set = function(value)
             db.profile.rollFrame.iconPosition = value
             if iconOutsideGapSlider then
@@ -328,7 +414,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         label = L["Icon Side"],
         tooltip = L["Place the icon on the left or right side of the frame"],
         values = ICON_SIDE_VALUES,
-        get = function() return db.profile.rollFrame.iconSide end,
+        get = function()
+            return db.profile.rollFrame.iconSide
+        end,
         set = function(value)
             db.profile.rollFrame.iconSide = value
             NotifyRollManager()
@@ -342,7 +430,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         min = 0,
         max = 30,
         step = 1,
-        get = function() return db.profile.rollFrame.iconOutsideGap end,
+        get = function()
+            return db.profile.rollFrame.iconOutsideGap
+        end,
         set = function(value)
             db.profile.rollFrame.iconOutsideGap = value
             NotifyRollManager()
@@ -357,7 +447,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         min = -20,
         max = 20,
         step = 1,
-        get = function() return db.profile.rollFrame.iconOffsetX end,
+        get = function()
+            return db.profile.rollFrame.iconOffsetX
+        end,
         set = function(value)
             db.profile.rollFrame.iconOffsetX = value
             NotifyRollManager()
@@ -371,7 +463,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         min = -20,
         max = 20,
         step = 1,
-        get = function() return db.profile.rollFrame.iconOffsetY end,
+        get = function()
+            return db.profile.rollFrame.iconOffsetY
+        end,
         set = function(value)
             db.profile.rollFrame.iconOffsetY = value
             NotifyRollManager()
@@ -381,10 +475,14 @@ local function CreateLayoutSection(parent, db, yOffset)
 
     local textureDropdown = W.CreateDropdown(content, {
         label = L["Timer Bar Texture"],
-        values = function() return LC.BuildLSMValues("statusbar") end,
+        values = function()
+            return LC.BuildLSMValues("statusbar")
+        end,
         sort = true,
         mediaType = "statusbar",
-        get = function() return db.profile.rollFrame.timerBarTexture end,
+        get = function()
+            return db.profile.rollFrame.timerBarTexture
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarTexture = value
             NotifyRollManager()
@@ -396,15 +494,19 @@ local function CreateLayoutSection(parent, db, yOffset)
     local timerBarHeader = W.CreateHeader(content, L["Timer Bar Appearance"])
     innerY = LC.AnchorWidget(timerBarHeader, content, innerY) - LC.SPACING_AFTER_HEADER
 
-    local borderColorPicker  -- forward declare
+    local borderColorPicker -- forward declare
 
     local borderToggle = W.CreateToggle(content, {
         label = L["Timer Bar Border"],
         tooltip = L["Show a border around the timer bar"],
-        get = function() return db.profile.rollFrame.timerBarBorder end,
+        get = function()
+            return db.profile.rollFrame.timerBarBorder
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarBorder = value
-            if borderColorPicker then borderColorPicker:SetDisabled(not value) end
+            if borderColorPicker then
+                borderColorPicker:SetDisabled(not value)
+            end
             NotifyRollManager()
         end,
     })
@@ -427,15 +529,19 @@ local function CreateLayoutSection(parent, db, yOffset)
     borderColorPicker:SetDisabled(not db.profile.rollFrame.timerBarBorder)
     innerY = LC.AnchorWidget(borderColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local barColorPicker  -- forward declare
+    local barColorPicker -- forward declare
 
     local colorModeDropdown = W.CreateDropdown(content, {
         label = L["Color Mode"],
         values = COLOR_MODE_VALUES,
-        get = function() return db.profile.rollFrame.timerBarColorMode end,
+        get = function()
+            return db.profile.rollFrame.timerBarColorMode
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarColorMode = value
-            if barColorPicker then barColorPicker:SetDisabled(value ~= "custom") end
+            if barColorPicker then
+                barColorPicker:SetDisabled(value ~= "custom")
+            end
             NotifyRollManager()
         end,
     })
@@ -481,7 +587,9 @@ local function CreateLayoutSection(parent, db, yOffset)
         step = 0.05,
         isPercent = true,
         format = "%.0f",
-        get = function() return db.profile.rollFrame.timerBarBackgroundAlpha end,
+        get = function()
+            return db.profile.rollFrame.timerBarBackgroundAlpha
+        end,
         set = function(value)
             db.profile.rollFrame.timerBarBackgroundAlpha = value
             NotifyRollManager()

--- a/DragonLoot_Options/Tabs/LootWindowTab.lua
+++ b/DragonLoot_Options/Tabs/LootWindowTab.lua
@@ -18,7 +18,7 @@ local math_abs = math.abs
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -57,7 +57,9 @@ local function CreateContent(parent)
     local enableToggle = W.CreateToggle(lootContent, {
         label = L["Enable Custom Loot Window"],
         tooltip = L["Replace the default loot window with DragonLoot's custom frame"],
-        get = function() return db.profile.lootWindow.enabled end,
+        get = function()
+            return db.profile.lootWindow.enabled
+        end,
         set = function(value)
             db.profile.lootWindow.enabled = value
             ApplyLootSettings()
@@ -69,7 +71,9 @@ local function CreateContent(parent)
     local lockToggle = W.CreateToggle(lootContent, {
         label = L["Lock Position"],
         tooltip = L["Prevent the loot window from being moved"],
-        get = function() return db.profile.lootWindow.lock end,
+        get = function()
+            return db.profile.lootWindow.lock
+        end,
         set = function(value)
             db.profile.lootWindow.lock = value
         end,
@@ -80,7 +84,9 @@ local function CreateContent(parent)
     local cursorToggle = W.CreateToggle(lootContent, {
         label = L["Position at Cursor"],
         tooltip = L["Open the loot window at the mouse cursor instead of the saved position"],
-        get = function() return db.profile.lootWindow.positionAtCursor end,
+        get = function()
+            return db.profile.lootWindow.positionAtCursor
+        end,
         set = function(value)
             db.profile.lootWindow.positionAtCursor = value
         end,
@@ -100,8 +106,12 @@ local function CreateContent(parent)
     -- Slider: Scale
     local scaleSlider = W.CreateSlider(layoutContent, {
         label = L["Scale"],
-        min = 0.5, max = 2, step = 0.05,
-        get = function() return db.profile.lootWindow.scale end,
+        min = 0.5,
+        max = 2,
+        step = 0.05,
+        get = function()
+            return db.profile.lootWindow.scale
+        end,
         set = function(value)
             db.profile.lootWindow.scale = value
             ApplyLootSettings()
@@ -112,9 +122,13 @@ local function CreateContent(parent)
     -- Slider: Width
     local widthSlider = W.CreateSlider(layoutContent, {
         label = L["Width"],
-        min = 150, max = 400, step = 10,
+        min = 150,
+        max = 400,
+        step = 10,
         format = "%d",
-        get = function() return db.profile.lootWindow.width end,
+        get = function()
+            return db.profile.lootWindow.width
+        end,
         set = function(value)
             db.profile.lootWindow.width = value
             ApplyLootSettings()
@@ -125,9 +139,13 @@ local function CreateContent(parent)
     -- Slider: Height
     local heightSlider = W.CreateSlider(layoutContent, {
         label = L["Height"],
-        min = 150, max = 600, step = 10,
+        min = 150,
+        max = 600,
+        step = 10,
         format = "%d",
-        get = function() return db.profile.lootWindow.height end,
+        get = function()
+            return db.profile.lootWindow.height
+        end,
         set = function(value)
             db.profile.lootWindow.height = value
             ApplyLootSettings()
@@ -138,30 +156,36 @@ local function CreateContent(parent)
     -- Slider: Slot Spacing
     local slotSpacingSlider = W.CreateSlider(layoutContent, {
         label = L["Slot Spacing"],
-        min = 0, max = 12, step = 1,
+        min = 0,
+        max = 12,
+        step = 1,
         format = "%d",
-        get = function() return db.profile.lootWindow.slotSpacing end,
+        get = function()
+            return db.profile.lootWindow.slotSpacing
+        end,
         set = function(value)
             db.profile.lootWindow.slotSpacing = value
             ApplyLootSettings()
         end,
     })
-    layoutY = LC.AnchorWidget(slotSpacingSlider, layoutContent, layoutY)
-        - LC.SPACING_BETWEEN_WIDGETS
+    layoutY = LC.AnchorWidget(slotSpacingSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Slider: Content Padding
     local contentPaddingSlider = W.CreateSlider(layoutContent, {
         label = L["Content Padding"],
-        min = 0, max = 12, step = 1,
+        min = 0,
+        max = 12,
+        step = 1,
         format = "%d",
-        get = function() return db.profile.lootWindow.contentPadding end,
+        get = function()
+            return db.profile.lootWindow.contentPadding
+        end,
         set = function(value)
             db.profile.lootWindow.contentPadding = value
             ApplyLootSettings()
         end,
     })
-    layoutY = LC.AnchorWidget(contentPaddingSlider, layoutContent, layoutY)
-        - LC.SPACING_BETWEEN_WIDGETS
+    layoutY = LC.AnchorWidget(contentPaddingSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     layoutSection:SetContentHeight(math_abs(layoutY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(layoutSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS

--- a/DragonLoot_Options/Tabs/NotificationsTab.lua
+++ b/DragonLoot_Options/Tabs/NotificationsTab.lua
@@ -20,7 +20,7 @@ local tonumber = tonumber
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -44,10 +44,14 @@ local function CreateNotificationSection(parent, db, yOffset)
     local showRollWon = W.CreateToggle(content, {
         label = L["Show Roll Won"],
         tooltip = L["Show a notification when someone wins a roll"],
-        get = function() return db.profile.rollNotifications.showRollWon end,
+        get = function()
+            return db.profile.rollNotifications.showRollWon
+        end,
         set = function(value)
             db.profile.rollNotifications.showRollWon = value
-            if groupWinsToggle then groupWinsToggle:SetDisabled(not value) end
+            if groupWinsToggle then
+                groupWinsToggle:SetDisabled(not value)
+            end
         end,
     })
     innerY = LC.AnchorWidget(showRollWon, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -55,8 +59,12 @@ local function CreateNotificationSection(parent, db, yOffset)
     groupWinsToggle = W.CreateToggle(content, {
         label = L["Show Group Wins"],
         tooltip = L["Show notifications when other group members win rolls"],
-        get = function() return db.profile.rollNotifications.showGroupWins end,
-        set = function(value) db.profile.rollNotifications.showGroupWins = value end,
+        get = function()
+            return db.profile.rollNotifications.showGroupWins
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showGroupWins = value
+        end,
         disabled = not db.profile.rollNotifications.showRollWon,
     })
     innerY = LC.AnchorWidget(groupWinsToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -64,11 +72,17 @@ local function CreateNotificationSection(parent, db, yOffset)
     local showRollResults = W.CreateToggle(content, {
         label = L["Show Roll Results"],
         tooltip = L["Show individual roll result notifications"],
-        get = function() return db.profile.rollNotifications.showRollResults end,
+        get = function()
+            return db.profile.rollNotifications.showRollResults
+        end,
         set = function(value)
             db.profile.rollNotifications.showRollResults = value
-            if selfRollsToggle then selfRollsToggle:SetDisabled(not value) end
-            if groupRollsToggle then groupRollsToggle:SetDisabled(not value) end
+            if selfRollsToggle then
+                selfRollsToggle:SetDisabled(not value)
+            end
+            if groupRollsToggle then
+                groupRollsToggle:SetDisabled(not value)
+            end
         end,
     })
     innerY = LC.AnchorWidget(showRollResults, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -76,8 +90,12 @@ local function CreateNotificationSection(parent, db, yOffset)
     selfRollsToggle = W.CreateToggle(content, {
         label = L["Show My Rolls"],
         tooltip = L["Show notifications for your own roll results"],
-        get = function() return db.profile.rollNotifications.showSelfRolls end,
-        set = function(value) db.profile.rollNotifications.showSelfRolls = value end,
+        get = function()
+            return db.profile.rollNotifications.showSelfRolls
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showSelfRolls = value
+        end,
         disabled = not db.profile.rollNotifications.showRollResults,
     })
     innerY = LC.AnchorWidget(selfRollsToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -85,8 +103,12 @@ local function CreateNotificationSection(parent, db, yOffset)
     groupRollsToggle = W.CreateToggle(content, {
         label = L["Show Group Rolls"],
         tooltip = L["Show notifications for other group members' roll results"],
-        get = function() return db.profile.rollNotifications.showGroupRolls end,
-        set = function(value) db.profile.rollNotifications.showGroupRolls = value end,
+        get = function()
+            return db.profile.rollNotifications.showGroupRolls
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showGroupRolls = value
+        end,
         disabled = not db.profile.rollNotifications.showRollResults,
     })
     innerY = LC.AnchorWidget(groupRollsToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -94,7 +116,9 @@ local function CreateNotificationSection(parent, db, yOffset)
     local qualityDropdown = W.CreateDropdown(content, {
         label = L["Minimum Quality"],
         values = ns.QualityValues,
-        get = function() return tostring(db.profile.rollNotifications.minQuality) end,
+        get = function()
+            return tostring(db.profile.rollNotifications.minQuality)
+        end,
         set = function(value)
             db.profile.rollNotifications.minQuality = tonumber(value) or 0
         end,
@@ -119,24 +143,36 @@ local function CreateInstanceFilterSection(parent, db, yOffset)
     local worldToggle = W.CreateToggle(content, {
         label = L["Show in Open World"],
         tooltip = L["Show roll notifications while in the open world"],
-        get = function() return db.profile.rollNotifications.showInWorld end,
-        set = function(value) db.profile.rollNotifications.showInWorld = value end,
+        get = function()
+            return db.profile.rollNotifications.showInWorld
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showInWorld = value
+        end,
     })
     innerY = LC.AnchorWidget(worldToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local dungeonToggle = W.CreateToggle(content, {
         label = L["Show in Dungeons"],
         tooltip = L["Show roll notifications while in dungeons"],
-        get = function() return db.profile.rollNotifications.showInDungeon end,
-        set = function(value) db.profile.rollNotifications.showInDungeon = value end,
+        get = function()
+            return db.profile.rollNotifications.showInDungeon
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showInDungeon = value
+        end,
     })
     innerY = LC.AnchorWidget(dungeonToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local raidToggle = W.CreateToggle(content, {
         label = L["Show in Raids"],
         tooltip = L["Show roll notifications while in raids"],
-        get = function() return db.profile.rollNotifications.showInRaid end,
-        set = function(value) db.profile.rollNotifications.showInRaid = value end,
+        get = function()
+            return db.profile.rollNotifications.showInRaid
+        end,
+        set = function(value)
+            db.profile.rollNotifications.showInRaid = value
+        end,
     })
     innerY = LC.AnchorWidget(raidToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 

--- a/DragonLoot_Options/Tabs/ProfilesTab.lua
+++ b/DragonLoot_Options/Tabs/ProfilesTab.lua
@@ -265,9 +265,12 @@ local function CreateContent(parent)
     local profilesContent = profilesSection.content
     local profilesY = -LC.SECTION_PADDING_TOP
 
+    -- stylua: ignore
     local desc = W.CreateDescription(
         profilesContent,
-        L["Profiles allow you to save different settings configurations. You can switch between" .. " profiles, copy settings from another profile, or reset to defaults."]
+        L["Profiles allow you to save different settings configurations."
+            .. " You can switch between profiles, copy settings from another profile,"
+            .. " or reset to defaults."]
     )
     profilesY = LC.AnchorWidget(desc, profilesContent, profilesY) - LC.SPACING_BETWEEN_WIDGETS
 

--- a/DragonLoot_Options/Tabs/ProfilesTab.lua
+++ b/DragonLoot_Options/Tabs/ProfilesTab.lua
@@ -23,7 +23,7 @@ local NO = NO
 -- DragonWidgets references
 -------------------------------------------------------------------------------
 
-local W  = ns.DW.Widgets
+local W = ns.DW.Widgets
 local LC = ns.DW.LayoutConstants
 
 -------------------------------------------------------------------------------
@@ -56,7 +56,9 @@ StaticPopupDialogs["DRAGONLOOT_RESET_PROFILE"] = {
     button2 = NO,
     OnAccept = function()
         local dl = ns.dlns
-        if not dl or not dl.Addon or not dl.Addon.db then return end
+        if not dl or not dl.Addon or not dl.Addon.db then
+            return
+        end
         dl.Addon.db:ResetProfile()
     end,
     timeout = 0,
@@ -66,14 +68,16 @@ StaticPopupDialogs["DRAGONLOOT_RESET_PROFILE"] = {
 }
 
 StaticPopupDialogs["DRAGONLOOT_DELETE_PROFILE"] = {
-    text = L["Are you sure you want to delete profile \"%s\"?"],
+    text = L['Are you sure you want to delete profile "%s"?'],
     button1 = YES,
     button2 = NO,
     OnAccept = function()
         if pendingDeleteProfile and pendingDeleteDb then
             pendingDeleteDb:DeleteProfile(pendingDeleteProfile)
             pendingDeleteProfile = nil
-            if pendingDeleteRefresh then pendingDeleteRefresh() end
+            if pendingDeleteRefresh then
+                pendingDeleteRefresh()
+            end
         end
     end,
     timeout = 0,
@@ -124,8 +128,12 @@ local function CreateCurrentProfileSection(parent, db, yOffset, refreshAll)
 
     local activeDropdown = W.CreateDropdown(content, {
         label = L["Active Profile"],
-        values = function() return GetProfileValues(db) end,
-        get = function() return db:GetCurrentProfile() end,
+        values = function()
+            return GetProfileValues(db)
+        end,
+        get = function()
+            return db:GetCurrentProfile()
+        end,
         set = function(value)
             db:SetProfile(value)
             refreshAll()
@@ -148,7 +156,9 @@ local function CreateCurrentProfileSection(parent, db, yOffset, refreshAll)
         tooltip = L["Create a new profile with the entered name and switch to it"],
         onClick = function()
             local name = newProfileInput:GetValue()
-            if not name or name == "" then return end
+            if not name or name == "" then
+                return
+            end
             db:SetProfile(name)
             newProfileInput:SetValue("")
             refreshAll()
@@ -177,8 +187,12 @@ local function CreateActionsSection(parent, db, yOffset, refreshAll)
     -- Copy From dropdown
     local copyDropdown = W.CreateDropdown(content, {
         label = L["Copy From"],
-        values = function() return GetOtherProfileValues(db) end,
-        get = function() return nil end,
+        values = function()
+            return GetOtherProfileValues(db)
+        end,
+        get = function()
+            return nil
+        end,
         set = function(value)
             db:CopyProfile(value)
             refreshAll()
@@ -201,8 +215,12 @@ local function CreateActionsSection(parent, db, yOffset, refreshAll)
     -- Delete Profile dropdown
     local deleteDropdown = W.CreateDropdown(content, {
         label = L["Delete Profile"],
-        values = function() return GetOtherProfileValues(db) end,
-        get = function() return nil end,
+        values = function()
+            return GetOtherProfileValues(db)
+        end,
+        get = function()
+            return nil
+        end,
         set = function(value)
             pendingDeleteProfile = value
             pendingDeleteDb = db
@@ -231,9 +249,15 @@ local function CreateContent(parent)
     local activeDropdown, copyDropdown, deleteDropdown
 
     local function RefreshProfileWidgets()
-        if activeDropdown then activeDropdown:Refresh() end
-        if copyDropdown then copyDropdown:Refresh() end
-        if deleteDropdown then deleteDropdown:Refresh() end
+        if activeDropdown then
+            activeDropdown:Refresh()
+        end
+        if copyDropdown then
+            copyDropdown:Refresh()
+        end
+        if deleteDropdown then
+            deleteDropdown:Refresh()
+        end
     end
 
     -- Profiles overview section
@@ -241,23 +265,20 @@ local function CreateContent(parent)
     local profilesContent = profilesSection.content
     local profilesY = -LC.SECTION_PADDING_TOP
 
-    local desc = W.CreateDescription(profilesContent,
-        L["Profiles allow you to save different settings configurations. You can switch between"
-        .. " profiles, copy settings from another profile, or reset to defaults."])
+    local desc = W.CreateDescription(
+        profilesContent,
+        L["Profiles allow you to save different settings configurations. You can switch between" .. " profiles, copy settings from another profile, or reset to defaults."]
+    )
     profilesY = LC.AnchorWidget(desc, profilesContent, profilesY) - LC.SPACING_BETWEEN_WIDGETS
 
     profilesSection:SetContentHeight(math_abs(profilesY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(profilesSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
 
     -- Current Profile section
-    yOffset, activeDropdown = CreateCurrentProfileSection(
-        parent, db, yOffset, RefreshProfileWidgets
-    )
+    yOffset, activeDropdown = CreateCurrentProfileSection(parent, db, yOffset, RefreshProfileWidgets)
 
     -- Profile Actions section
-    yOffset, copyDropdown, deleteDropdown = CreateActionsSection(
-        parent, db, yOffset, RefreshProfileWidgets
-    )
+    yOffset, copyDropdown, deleteDropdown = CreateActionsSection(parent, db, yOffset, RefreshProfileWidgets)
 
     parent:SetHeight(math_abs(yOffset) + LC.PADDING_BOTTOM)
 end

--- a/justfile
+++ b/justfile
@@ -1,0 +1,24 @@
+# DragonLoot development tasks
+
+# List available recipes
+default:
+    @just --list
+
+# Run busted test suite
+test:
+    mise run test
+
+# Run luacheck linter
+lint:
+    mise run lint
+
+# Format Lua files with StyLua
+fmt:
+    stylua DragonLoot/ DragonLoot_Options/ spec/
+
+# Format check only (no writes)
+fmt-check:
+    stylua --check DragonLoot/ DragonLoot_Options/ spec/
+
+# Run lint and tests
+check: lint test

--- a/spec/Config_spec.lua
+++ b/spec/Config_spec.lua
@@ -140,19 +140,21 @@ describe("Config", function()
             assert.is_nil(db.profile.appearance.iconSize)
         end)
 
-        it("copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v2)",
+        it(
+            "copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v2)",
             function()
-            local db = initWithSeed(ns, {
-                schemaVersion = 2,
-                appearance = {
-                    iconSize = 48,
-                    -- lootIconSize intentionally absent to test migration propagation
-                },
-            })
+                local db = initWithSeed(ns, {
+                    schemaVersion = 2,
+                    appearance = {
+                        iconSize = 48,
+                        -- lootIconSize intentionally absent to test migration propagation
+                    },
+                })
 
-            assert.are.equal(48, db.profile.appearance.lootIconSize)
-            assert.is_nil(db.profile.appearance.iconSize)
-        end)
+                assert.are.equal(48, db.profile.appearance.lootIconSize)
+                assert.is_nil(db.profile.appearance.iconSize)
+            end
+        )
     end)
 
     ---------------------------------------------------------------------------

--- a/spec/Lifecycle_spec.lua
+++ b/spec/Lifecycle_spec.lua
@@ -68,9 +68,9 @@ describe("LifecycleUtil", function()
 
         it("increments the token when called", function()
             local state = LU.CreateState()
-            LU.Activate(state)        -- token = 1
+            LU.Activate(state) -- token = 1
 
-            LU.Invalidate(state)      -- token must be 2
+            LU.Invalidate(state) -- token must be 2
 
             assert.are.equal(2, state.token)
         end)
@@ -132,8 +132,8 @@ describe("LifecycleUtil", function()
 
         it("returns false with the old token after Invalidate (token was incremented)", function()
             local state = LU.CreateState()
-            local token = LU.Activate(state)   -- token = 1, captured
-            LU.Invalidate(state)               -- token becomes 2
+            local token = LU.Activate(state) -- token = 1, captured
+            LU.Invalidate(state) -- token becomes 2
 
             assert.are.equal(2, state.token)
             assert.is_false(LU.IsTokenCurrent(state, token))
@@ -179,7 +179,9 @@ describe("LifecycleUtil", function()
             local guarded = LU.Guard(state, token, "not a function")
 
             assert.is_function(guarded)
-            assert.has_no.errors(function() guarded() end)
+            assert.has_no.errors(function()
+                guarded()
+            end)
         end)
     end)
 
@@ -204,18 +206,22 @@ describe("LifecycleUtil", function()
             local state = LU.CreateState()
             LU.Activate(state)
             local wasCalled = false
-            local savedAfter = C_Timer.After  -- backup before override
+            local savedAfter = C_Timer.After -- backup before override
 
             local savedCb
-            C_Timer.After = function(_, cb)   -- luacheck: ignore 121 122 212
+            C_Timer.After = function(_, cb) -- luacheck: ignore 121 122 212
                 savedCb = cb
             end
 
-            LU.After(state, 1, function() wasCalled = true end)
+            LU.After(state, 1, function()
+                wasCalled = true
+            end)
             LU.Invalidate(state)
-            if savedCb then savedCb() end
+            if savedCb then
+                savedCb()
+            end
 
-            C_Timer.After = savedAfter        -- luacheck: ignore 122
+            C_Timer.After = savedAfter -- luacheck: ignore 122
 
             assert.is_false(wasCalled)
         end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -58,10 +58,14 @@ WOW_PROJECT_MAINLINE = 1
 
 C_Timer = {
     After = function(_, cb)
-        if cb then cb() end
+        if cb then
+            cb()
+        end
     end,
     NewTicker = function(_, cb)
-        if cb then cb() end
+        if cb then
+            cb()
+        end
         return { Cancel = function() end }
     end,
 }
@@ -86,7 +90,9 @@ function strsplit(delimiter, str, max)
     for part in string.gmatch(str .. delimiter, pattern) do
         count = count + 1
         parts[count] = part
-        if max and count >= max then break end
+        if max and count >= max then
+            break
+        end
     end
     return unpack(parts)
 end
@@ -114,9 +120,15 @@ local function CreateMockFrame()
 
     function frame.SetPoint() end
     function frame.ClearAllPoints() end
-    function frame:Show() self._shown = true end
-    function frame:Hide() self._shown = false end
-    function frame:IsShown() return self._shown end
+    function frame:Show()
+        self._shown = true
+    end
+    function frame:Hide()
+        self._shown = false
+    end
+    function frame:IsShown()
+        return self._shown
+    end
     function frame.SetSize() end
     function frame.SetHeight() end
     function frame.SetWidth() end
@@ -124,13 +136,25 @@ local function CreateMockFrame()
     function frame.EnableMouse() end
     function frame.SetFrameStrata() end
     function frame.SetScript() end
-    function frame.CreateTexture() return {} end
-    function frame.CreateFontString() return { SetFont = function() end, SetText = function() end } end
+    function frame.CreateTexture()
+        return {}
+    end
+    function frame.CreateFontString()
+        return { SetFont = function() end, SetText = function() end }
+    end
 
-    function frame:RegisterEvent(event) self._events[event] = true end
-    function frame:UnregisterEvent(event) self._events[event] = nil end
-    function frame:UnregisterAllEvents() wipe(self._events) end
-    function frame:IsEventRegistered(event) return self._events[event] or false end
+    function frame:RegisterEvent(event)
+        self._events[event] = true
+    end
+    function frame:UnregisterEvent(event)
+        self._events[event] = nil
+    end
+    function frame:UnregisterAllEvents()
+        wipe(self._events)
+    end
+    function frame:IsEventRegistered(event)
+        return self._events[event] or false
+    end
 
     return frame
 end
@@ -148,7 +172,9 @@ _G = _G or {}
 -------------------------------------------------------------------------------
 
 local function DeepCopyTable(src)
-    if type(src) ~= "table" then return src end
+    if type(src) ~= "table" then
+        return src
+    end
     local copy = {}
     for k, v in pairs(src) do
         copy[k] = DeepCopyTable(v)
@@ -185,7 +211,9 @@ local aceAddonMock = {
         function addon:RegisterEvent() end
         function addon:UnregisterEvent() end
         function addon.ScheduleTimer(_, func, _)
-            if func then func() end
+            if func then
+                func()
+            end
             return {}
         end
         function addon.ScheduleRepeatingTimer()
@@ -207,9 +235,15 @@ local aceLocaleMock = {
 }
 
 function LibStub(name)
-    if name == "AceDB-3.0" then return aceDBMock end
-    if name == "AceAddon-3.0" then return aceAddonMock end
-    if name == "AceLocale-3.0" then return aceLocaleMock end
+    if name == "AceDB-3.0" then
+        return aceDBMock
+    end
+    if name == "AceAddon-3.0" then
+        return aceAddonMock
+    end
+    if name == "AceLocale-3.0" then
+        return aceLocaleMock
+    end
     return nil
 end
 
@@ -258,7 +292,9 @@ end
 function M.LoadLifecycle(ns)
     local path = "DragonLoot/Core/Lifecycle.lua"
     local chunk, err = loadfile(path)
-    if not chunk then error("Failed to load " .. path .. ": " .. tostring(err)) end
+    if not chunk then
+        error("Failed to load " .. path .. ": " .. tostring(err))
+    end
     chunk("DragonLoot", ns)
     return ns.LifecycleUtil
 end
@@ -266,7 +302,9 @@ end
 function M.LoadConfig(ns)
     local path = "DragonLoot/Core/Config.lua"
     local chunk, err = loadfile(path)
-    if not chunk then error("Failed to load " .. path .. ": " .. tostring(err)) end
+    if not chunk then
+        error("Failed to load " .. path .. ": " .. tostring(err))
+    end
     chunk("DragonLoot", ns)
 end
 


### PR DESCRIPTION
## Summary

Add StyLua code formatter configuration, a justfile for development tasks, and apply consistent formatting across the codebase.

## Changes

- `.stylua.toml` - StyLua config (120 col width, 4-space indent, Unix line endings, double quotes)
- `justfile` - Development task runner with test, lint, fmt, fmt-check, and check recipes
- `.mise.toml` - Added stylua to mise tool definitions
- `AGENTS.md` - Added Development Commands section documenting just recipes, mise tasks, and code style
- `DragonLoot/`, `DragonLoot_Options/`, `spec/` - Code formatted with StyLua

## Notes

- No functional changes - formatting only on Lua files
- StyLua ensures consistent style going forward
- Justfile provides convenient aliases for common dev workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added formatter tooling configuration and environment path adjustments for development
  * Added developer automation recipes for lint/test/format

* **Style**
  * Standardized code formatting and converted terse inline conditionals to clearer block form
  * No user-facing behavior changes

* **Documentation**
  * Added development commands and coding style guidelines for contributors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->