### PR TITLE
fix: correct DragonWidgets external path in .pkgmeta (#136)

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -12,7 +12,7 @@ externals:
   DragonLoot/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   DragonLoot/Libs/LibSharedMedia-3.0: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
   DragonLoot/Libs/LibAnimate: https://github.com/Xerrion/LibAnimate
-  DragonLoot/DragonLoot_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
+  DragonLoot_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
 
 ignore:
   - ".git*"


### PR DESCRIPTION
## Summary

The DragonWidgets external path in .pkgmeta had an incorrect prefix that prevented the BigWigsMods packager from placing it in the right location.

**Before:**
`yaml
DragonLoot/DragonLoot_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
`

**After:**
`yaml
DragonLoot_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
`

The move-folders directive maps DragonLoot/DragonLoot_Options -> DragonLoot_Options. The external path key must match the **pre-move** structure relative to the repo root. Using the DragonLoot/ prefix caused the packager to place DragonWidgets inside a stray nested DragonLoot/DragonLoot_Options/ folder instead of DragonLoot_Options/Libs/DragonWidgets/, making DragonWidgetsNS undefined at runtime.

## Type of Change
- [x] Bug fix

## Testing
- Packaging: trigger packager.yml and verify DragonWidgets lands in DragonLoot_Options/Libs/DragonWidgets/DragonWidgets/ in the built zip.

## Checklist
- [x] .pkgmeta external path corrected
- [x] No other files changed

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration to ensure proper module resolution for DragonWidgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->