### PR TITLE
fix: remove invalid UpdateTooltip script handler on Button frames

### DIFF
--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -320,14 +320,6 @@ local function OnSlotLeave(self)
     self.itemName:SetTextColor(r, g, b)
 end
 
-local function OnSlotUpdateTooltip(self)
-    if self.slotIndex then
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:SetLootItem(self.slotIndex)
-        GameTooltip:Show()
-    end
-end
-
 -------------------------------------------------------------------------------
 -- Slot frame creation
 -------------------------------------------------------------------------------
@@ -410,7 +402,6 @@ local function CreateSlotFrame()
     slot:SetScript("OnClick", OnSlotClick)
     slot:SetScript("OnEnter", OnSlotEnter)
     slot:SetScript("OnLeave", OnSlotLeave)
-    slot:SetScript("UpdateTooltip", OnSlotUpdateTooltip)
 
     return slot
 end
@@ -457,7 +448,6 @@ local function ReleaseSlot(slot)
     slot:SetScript("OnClick", OnSlotClick)
     slot:SetScript("OnEnter", OnSlotEnter)
     slot:SetScript("OnLeave", OnSlotLeave)
-    slot:SetScript("UpdateTooltip", OnSlotUpdateTooltip)
 
     table.insert(slotPool, slot)
 end
@@ -660,7 +650,6 @@ local function RenderSlot(slot, data, isTest)
         slot:SetScript("OnClick", OnSlotClick)
         slot:SetScript("OnEnter", OnSlotEnter)
         slot:SetScript("OnLeave", OnSlotLeave)
-        slot:SetScript("UpdateTooltip", OnSlotUpdateTooltip)
     end
 
     slot:Show()

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -561,7 +561,6 @@ local function CreateRollIcon(parent)
     btn:SetScript("OnEnter", OnIconEnter)
     btn:SetScript("OnLeave", OnIconLeave)
     btn:SetScript("OnClick", OnIconClick)
-    btn:SetScript("UpdateTooltip", OnIconEnter)
 
     return btn
 end


### PR DESCRIPTION
## What
Remove `SetScript("UpdateTooltip", ...)` calls on `Button` frames in `RollFrame.lua` and `LootFrame.lua`.

`UpdateTooltip` is not a valid script handler for `Button` frames - it only exists on `GameTooltip`. Setting it on a Button caused the crash:
> Button:GetScript(): Doesn't have a "UpdateTooltip" script

## Changes
- `RollFrame.lua`: Removed `btn:SetScript("UpdateTooltip", OnIconEnter)` from `CreateRollIcon`
- `LootFrame.lua`: Removed 3 `slot:SetScript("UpdateTooltip", OnSlotUpdateTooltip)` calls and the now-dead `OnSlotUpdateTooltip` function

Tooltip behavior is unchanged - `OnEnter`/`OnLeave` handlers handle all tooltip display correctly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- `luacheck .` passes with 0 new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal tooltip handling by removing redundant code. Tooltip functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->