### PR TITLE
feat: redesign options UI for natural UX flow (#124)

### DIFF
--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -172,6 +172,10 @@ L["Slot Spacing"] = true
 L["Width"] = true
 
 -- DragonLoot_Options/Tabs/LootRollTab.lua
+L["Buttons"] = true
+L["Frame"] = true
+L["Icon"] = true
+L["Timer Bar"] = true
 L["Button Size"] = true
 L["Button Spacing"] = true
 L["Compact Text Layout"] = true
@@ -240,11 +244,14 @@ L["Width of the roll frame"] = true
 L["Notifications"] = true
 
 -- DragonLoot_Options/Tabs/HistoryTab.lua
+L["Display"] = true
+L["Recording"] = true
 L["Auto Show on Loot"] = true
 L["Enable History"] = true
 L["Entry Spacing"] = true
 L["History"] = true
 L["Max Entries"] = true
+L["Prevent the history frame from being moved"] = true
 L["Track Direct Loot"] = true
 L["Track items you pick up directly (not from a loot window)"] = true
 L["Roll Details"] = true
@@ -252,6 +259,7 @@ L["Show Roll Details"] = true
 L["Click history entries to expand and see all player rolls"] = true
 
 -- DragonLoot_Options/Tabs/AutoLootTab.lua
+L["Settings"] = true
 L["Auto-Loot"] = true
 -- stylua: ignore
 L["Automatically loot items that meet your criteria."
@@ -309,6 +317,7 @@ L["Text Shadow"] = true
 L["Enable text shadow on all text elements"] = true
 
 -- DragonLoot_Options/Tabs/AnimationTab.lua
+L["Global Settings"] = true
 L["Animation"] = true
 L["Close Animation"] = true
 L["Close Duration"] = true

--- a/DragonLoot_Options/Tabs/AnimationTab.lua
+++ b/DragonLoot_Options/Tabs/AnimationTab.lua
@@ -75,7 +75,7 @@ local function CreateAnimDropdown(content, db, innerY, label, key, valuesFn)
             LC.NotifyAppearanceChange()
         end,
     })
-    return LC.AnchorWidget(dropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    return LC.AnchorWidget(dropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS, dropdown
 end
 
 -------------------------------------------------------------------------------
@@ -86,11 +86,12 @@ local function CreateContent(parent)
     dlns = ns.dlns
     local db = dlns.Addon.db
     local yOffset = LC.PADDING_TOP
+    local animWidgets = {}
 
     ---------------------------------------------------------------------------
-    -- Section: Animation (global toggle + durations)
+    -- Section: Global Settings (global toggle + durations)
     ---------------------------------------------------------------------------
-    local animSection = W.CreateSection(parent, L["Animation"])
+    local animSection = W.CreateSection(parent, L["Global Settings"])
     local animContent = animSection.content
     local animY = -LC.SECTION_PADDING_TOP
 
@@ -103,6 +104,9 @@ local function CreateContent(parent)
         set = function(value)
             db.profile.animation.enabled = value
             LC.NotifyAppearanceChange()
+            for _, widget in ipairs(animWidgets) do
+                widget:SetDisabled(not value)
+            end
         end,
     })
     animY = LC.AnchorWidget(enableToggle, animContent, animY) - LC.SPACING_BETWEEN_WIDGETS
@@ -122,6 +126,7 @@ local function CreateContent(parent)
             LC.NotifyAppearanceChange()
         end,
     })
+    animWidgets[#animWidgets + 1] = openDuration
     animY = LC.AnchorWidget(openDuration, animContent, animY) - LC.SPACING_BETWEEN_WIDGETS
 
     local closeDuration = W.CreateSlider(animContent, {
@@ -139,6 +144,7 @@ local function CreateContent(parent)
             LC.NotifyAppearanceChange()
         end,
     })
+    animWidgets[#animWidgets + 1] = closeDuration
     animY = LC.AnchorWidget(closeDuration, animContent, animY) - LC.SPACING_BETWEEN_WIDGETS
 
     animSection:SetContentHeight(math_abs(animY) + LC.SECTION_PADDING_BOTTOM)
@@ -151,8 +157,17 @@ local function CreateContent(parent)
     local lootContent = lootSection.content
     local lootY = -LC.SECTION_PADDING_TOP
 
-    lootY = CreateAnimDropdown(lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues)
-    lootY = CreateAnimDropdown(lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues)
+    local lootOpenDropdown
+    lootY, lootOpenDropdown = CreateAnimDropdown(
+        lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues
+    )
+    animWidgets[#animWidgets + 1] = lootOpenDropdown
+
+    local lootCloseDropdown
+    lootY, lootCloseDropdown = CreateAnimDropdown(
+        lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues
+    )
+    animWidgets[#animWidgets + 1] = lootCloseDropdown
 
     lootSection:SetContentHeight(math_abs(lootY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(lootSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
@@ -164,11 +179,29 @@ local function CreateContent(parent)
     local rollContent = rollSection.content
     local rollY = -LC.SECTION_PADDING_TOP
 
-    rollY = CreateAnimDropdown(rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues)
-    rollY = CreateAnimDropdown(rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues)
+    local rollShowDropdown
+    rollY, rollShowDropdown = CreateAnimDropdown(
+        rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues
+    )
+    animWidgets[#animWidgets + 1] = rollShowDropdown
+
+    local rollHideDropdown
+    rollY, rollHideDropdown = CreateAnimDropdown(
+        rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues
+    )
+    animWidgets[#animWidgets + 1] = rollHideDropdown
 
     rollSection:SetContentHeight(math_abs(rollY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(rollSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    ---------------------------------------------------------------------------
+    -- Apply initial disabled state
+    ---------------------------------------------------------------------------
+    if not db.profile.animation.enabled then
+        for _, widget in ipairs(animWidgets) do
+            widget:SetDisabled(true)
+        end
+    end
 
     ---------------------------------------------------------------------------
     -- Set content height for scroll frame

--- a/DragonLoot_Options/Tabs/AutoLootTab.lua
+++ b/DragonLoot_Options/Tabs/AutoLootTab.lua
@@ -40,7 +40,7 @@ local ITEM_LIST_HEIGHT = 220
 -------------------------------------------------------------------------------
 
 local function CreateSettingsSection(parent, db, yOffset)
-    local section = W.CreateSection(parent, L["Smart Auto-Loot"])
+    local section = W.CreateSection(parent, L["Settings"])
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
@@ -54,6 +54,9 @@ local function CreateSettingsSection(parent, db, yOffset)
     )
     innerY = LC.AnchorWidget(desc, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
+    -- Forward-declare so the toggle set closure captures the variable
+    local qualityDropdown
+
     local enableToggle = W.CreateToggle(content, {
         label = L["Enable Smart Auto-Loot"],
         tooltip = L["When enabled, qualifying items are automatically looted based on your filter rules"],
@@ -62,11 +65,12 @@ local function CreateSettingsSection(parent, db, yOffset)
         end,
         set = function(value)
             db.profile.autoLoot.enabled = value
+            qualityDropdown:SetDisabled(not value)
         end,
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local qualityDropdown = W.CreateDropdown(content, {
+    qualityDropdown = W.CreateDropdown(content, {
         label = L["Minimum Quality"],
         values = ns.QualityValues,
         get = function()
@@ -77,6 +81,9 @@ local function CreateSettingsSection(parent, db, yOffset)
         end,
     })
     innerY = LC.AnchorWidget(qualityDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    -- Apply initial disabled state
+    qualityDropdown:SetDisabled(not db.profile.autoLoot.enabled)
 
     section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS

--- a/DragonLoot_Options/Tabs/HistoryTab.lua
+++ b/DragonLoot_Options/Tabs/HistoryTab.lua
@@ -40,10 +40,10 @@ local function ApplyHistorySettings()
 end
 
 -------------------------------------------------------------------------------
--- Section: History (toggles, dropdown, roll details)
+-- Section: History (master controls)
 -------------------------------------------------------------------------------
 
-local function CreateTogglesSection(parent, db, yOffset)
+local function CreateHistorySection(parent, db, yOffset)
     local section = W.CreateSection(parent, L["History"])
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
@@ -61,6 +61,20 @@ local function CreateTogglesSection(parent, db, yOffset)
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
+    -- Lock Position
+    local lockToggle = W.CreateToggle(content, {
+        label = L["Lock Position"],
+        tooltip = L["Prevent the history frame from being moved"],
+        get = function()
+            return db.profile.history.lock
+        end,
+        set = function(value)
+            db.profile.history.lock = value
+            ApplyHistorySettings()
+        end,
+    })
+    innerY = LC.AnchorWidget(lockToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
     -- Auto Show on Loot
     local autoShowToggle = W.CreateToggle(content, {
         label = L["Auto Show on Loot"],
@@ -72,6 +86,21 @@ local function CreateTogglesSection(parent, db, yOffset)
         end,
     })
     innerY = LC.AnchorWidget(autoShowToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Section: Recording (what to capture)
+-------------------------------------------------------------------------------
+
+local function CreateRecordingSection(parent, db, yOffset)
+    local section = W.CreateSection(parent, L["Recording"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
 
     -- Forward-declare so the toggle set closure captures the variable
     local qualityDropdown
@@ -108,9 +137,20 @@ local function CreateTogglesSection(parent, db, yOffset)
     -- Apply initial disabled state based on current trackDirectLoot value
     qualityDropdown:SetDisabled(not db.profile.history.trackDirectLoot)
 
-    -- Roll Details sub-header (visual separator inside section)
-    local detailsHeader = W.CreateHeader(content, L["Roll Details"])
-    innerY = LC.AnchorWidget(detailsHeader, content, innerY) - LC.SPACING_AFTER_HEADER
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Section: Display (how it looks + what to show)
+-------------------------------------------------------------------------------
+
+local function CreateDisplaySection(parent, db, yOffset)
+    local section = W.CreateSection(parent, L["Display"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
 
     -- Show Roll Details toggle
     local rollDetailsToggle = W.CreateToggle(content, {
@@ -125,21 +165,6 @@ local function CreateTogglesSection(parent, db, yOffset)
         end,
     })
     innerY = LC.AnchorWidget(rollDetailsToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
-    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
-
-    return yOffset
-end
-
--------------------------------------------------------------------------------
--- Section: Layout (sliders)
--------------------------------------------------------------------------------
-
-local function CreateLayoutSection(parent, db, yOffset)
-    local section = W.CreateSection(parent, L["Layout"])
-    local content = section.content
-    local innerY = -LC.SECTION_PADDING_TOP
 
     -- Slider: Max Entries
     local maxEntriesSlider = W.CreateSlider(content, {
@@ -206,11 +231,14 @@ local function CreateContent(parent)
     local db = dlns.Addon.db
     local yOffset = LC.PADDING_TOP
 
-    -- History toggles and dropdown section
-    yOffset = CreateTogglesSection(parent, db, yOffset)
+    -- History master controls section
+    yOffset = CreateHistorySection(parent, db, yOffset)
 
-    -- Layout sliders section
-    yOffset = CreateLayoutSection(parent, db, yOffset)
+    -- Recording section
+    yOffset = CreateRecordingSection(parent, db, yOffset)
+
+    -- Display section
+    yOffset = CreateDisplaySection(parent, db, yOffset)
 
     -- Set content height for scroll frame
     parent:SetHeight(math_abs(yOffset) + LC.PADDING_BOTTOM)

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -1,6 +1,6 @@
 -------------------------------------------------------------------------------
 -- LootRollTab.lua
--- Loot Roll settings tab: roll frame layout and timer bar
+-- Roll Frame settings tab: roll frame controls, layout, timer bar, and icon
 --
 -- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
 -------------------------------------------------------------------------------
@@ -13,6 +13,7 @@ local L = ns.L
 -------------------------------------------------------------------------------
 
 local math_abs = math.abs
+local ipairs = ipairs
 
 -------------------------------------------------------------------------------
 -- DragonWidgets references
@@ -62,10 +63,37 @@ local ICON_SIDE_VALUES = {
 }
 
 -------------------------------------------------------------------------------
+-- Helper: create a roll frame layout slider inside the given content frame
+-------------------------------------------------------------------------------
+
+local function CreateLayoutSlider(content, db, innerY, label, tooltip, key, min, max, step, fmt, layoutWidgets)
+    local slider = W.CreateSlider(content, {
+        label = label,
+        tooltip = tooltip,
+        min = min,
+        max = max,
+        step = step,
+        format = fmt,
+        get = function()
+            return db.profile.rollFrame[key]
+        end,
+        set = function(value)
+            db.profile.rollFrame[key] = value
+            NotifyRollManager()
+        end,
+    })
+    if layoutWidgets then
+        layoutWidgets[#layoutWidgets + 1] = slider
+    end
+    innerY = LC.AnchorWidget(slider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    return innerY
+end
+
+-------------------------------------------------------------------------------
 -- Section: Roll Frame (basic settings)
 -------------------------------------------------------------------------------
 
-local function CreateRollFrameSection(parent, db, yOffset)
+local function CreateRollFrameSection(parent, db, yOffset, layoutWidgets, reapplySubState)
     local section = W.CreateSection(parent, L["Roll Frame"])
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
@@ -79,6 +107,15 @@ local function CreateRollFrameSection(parent, db, yOffset)
         set = function(value)
             db.profile.rollFrame.enabled = value
             NotifyRollManager()
+            for _, widget in ipairs(layoutWidgets) do
+                widget:SetDisabled(not value)
+            end
+            -- Re-apply sub-state after re-enabling
+            if value then
+                for _, fn in ipairs(reapplySubState) do
+                    fn()
+                end
+            end
         end,
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
@@ -93,6 +130,7 @@ local function CreateRollFrameSection(parent, db, yOffset)
             db.profile.rollFrame.lock = value
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = lockToggle
     innerY = LC.AnchorWidget(lockToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local hideOnVoteToggle = W.CreateToggle(content, {
@@ -107,6 +145,7 @@ local function CreateRollFrameSection(parent, db, yOffset)
             db.profile.rollFrame.hideOnVote = value
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = hideOnVoteToggle
     innerY = LC.AnchorWidget(hideOnVoteToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local centerHBtn = W.CreateButton(content, {
@@ -168,35 +207,11 @@ local function CreateRollFrameSection(parent, db, yOffset)
 end
 
 -------------------------------------------------------------------------------
--- Helper: create a roll frame layout slider inside the given content frame
+-- Section: Frame (frame dimensions and compact layout)
 -------------------------------------------------------------------------------
 
-local function CreateLayoutSlider(content, db, innerY, label, tooltip, key, min, max, step, fmt)
-    local slider = W.CreateSlider(content, {
-        label = label,
-        tooltip = tooltip,
-        min = min,
-        max = max,
-        step = step,
-        format = fmt,
-        get = function()
-            return db.profile.rollFrame[key]
-        end,
-        set = function(value)
-            db.profile.rollFrame[key] = value
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(slider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-    return innerY
-end
-
--------------------------------------------------------------------------------
--- Section: Layout (sliders + texture dropdown)
--------------------------------------------------------------------------------
-
-local function CreateLayoutSection(parent, db, yOffset)
-    local section = W.CreateSection(parent, L["Layout"])
+local function CreateFrameSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    local section = W.CreateSection(parent, L["Frame"])
     local content = section.content
     local innerY = -LC.SECTION_PADDING_TOP
 
@@ -220,20 +235,15 @@ local function CreateLayoutSection(parent, db, yOffset)
         end,
     })
     frameMinHeightSlider:SetDisabled(isCompact)
+    layoutWidgets[#layoutWidgets + 1] = frameMinHeightSlider
     innerY = LC.AnchorWidget(frameMinHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    innerY = CreateLayoutSlider(content, db, innerY, L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f")
     innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Frame Width"],
-        L["Width of the roll frame"],
-        "frameWidth",
-        200,
-        500,
-        10,
-        "%d"
+        content, db, innerY, L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f", layoutWidgets
+    )
+    innerY = CreateLayoutSlider(
+        content, db, innerY, L["Frame Width"], L["Width of the roll frame"], "frameWidth", 200, 500, 10, "%d",
+        layoutWidgets
     )
 
     rowSpacingSlider = W.CreateSlider(content, {
@@ -252,9 +262,50 @@ local function CreateLayoutSection(parent, db, yOffset)
         end,
     })
     rowSpacingSlider:SetDisabled(isCompact)
+    layoutWidgets[#layoutWidgets + 1] = rowSpacingSlider
     innerY = LC.AnchorWidget(rowSpacingSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    -- Timer Bar Style dropdown + height sliders
+    local compactToggle = W.CreateToggle(content, {
+        label = L["Compact Text Layout"],
+        tooltip = L["Show item name and bind type on the same line"],
+        get = function()
+            return db.profile.rollFrame.compactTextLayout
+        end,
+        set = function(value)
+            db.profile.rollFrame.compactTextLayout = value
+            if frameMinHeightSlider then
+                frameMinHeightSlider:SetDisabled(value)
+            end
+            if rowSpacingSlider then
+                rowSpacingSlider:SetDisabled(value)
+            end
+            NotifyRollManager()
+        end,
+    })
+    layoutWidgets[#layoutWidgets + 1] = compactToggle
+    innerY = LC.AnchorWidget(compactToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    reapplySubState[#reapplySubState + 1] = function()
+        local isCompactNow = db.profile.rollFrame.compactTextLayout
+        frameMinHeightSlider:SetDisabled(isCompactNow)
+        rowSpacingSlider:SetDisabled(isCompactNow)
+    end
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Section: Timer Bar (style, height, texture, colors)
+-------------------------------------------------------------------------------
+
+local function CreateTimerBarSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    local section = W.CreateSection(parent, L["Timer Bar"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
+
     local timerBarHeightSlider, minimalHeightSlider -- forward declare
 
     local styleDropdown = W.CreateDropdown(content, {
@@ -275,6 +326,7 @@ local function CreateLayoutSection(parent, db, yOffset)
             NotifyRollManager()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = styleDropdown
     innerY = LC.AnchorWidget(styleDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     timerBarHeightSlider = W.CreateSlider(content, {
@@ -293,6 +345,7 @@ local function CreateLayoutSection(parent, db, yOffset)
         end,
     })
     timerBarHeightSlider:SetDisabled(db.profile.rollFrame.timerBarStyle == "minimal")
+    layoutWidgets[#layoutWidgets + 1] = timerBarHeightSlider
     innerY = LC.AnchorWidget(timerBarHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     minimalHeightSlider = W.CreateSlider(content, {
@@ -311,87 +364,195 @@ local function CreateLayoutSection(parent, db, yOffset)
         end,
     })
     minimalHeightSlider:SetDisabled(db.profile.rollFrame.timerBarStyle ~= "minimal")
+    layoutWidgets[#layoutWidgets + 1] = minimalHeightSlider
     innerY = LC.AnchorWidget(minimalHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Timer Bar Spacing"],
-        L["Space between item row and timer bar"],
-        "timerBarSpacing",
-        0,
-        16,
-        1,
-        "%d"
-    )
-    innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Content Padding"],
-        L["Inner padding of the roll frame"],
-        "contentPadding",
-        0,
-        12,
-        1,
-        "%d"
-    )
-    innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Button Size"],
-        L["Size of Need/Greed/Pass buttons"],
-        "buttonSize",
-        16,
-        36,
-        1,
-        "%d"
-    )
-    innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Button Spacing"],
-        L["Spacing between roll buttons"],
-        "buttonSpacing",
-        0,
-        12,
-        1,
-        "%d"
-    )
-    innerY = CreateLayoutSlider(
-        content,
-        db,
-        innerY,
-        L["Frame Spacing"],
-        L["Spacing between multiple roll frames"],
-        "frameSpacing",
-        0,
-        16,
-        1,
-        "%d"
+        content, db, innerY, L["Timer Bar Spacing"], L["Space between item row and timer bar"], "timerBarSpacing",
+        0, 16, 1, "%d", layoutWidgets
     )
 
-    local compactToggle = W.CreateToggle(content, {
-        label = L["Compact Text Layout"],
-        tooltip = L["Show item name and bind type on the same line"],
+    local textureDropdown = W.CreateDropdown(content, {
+        label = L["Timer Bar Texture"],
+        values = function()
+            return LC.BuildLSMValues("statusbar")
+        end,
+        sort = true,
+        mediaType = "statusbar",
         get = function()
-            return db.profile.rollFrame.compactTextLayout
+            return db.profile.rollFrame.timerBarTexture
         end,
         set = function(value)
-            db.profile.rollFrame.compactTextLayout = value
-            if frameMinHeightSlider then
-                frameMinHeightSlider:SetDisabled(value)
-            end
-            if rowSpacingSlider then
-                rowSpacingSlider:SetDisabled(value)
+            db.profile.rollFrame.timerBarTexture = value
+            NotifyRollManager()
+        end,
+    })
+    layoutWidgets[#layoutWidgets + 1] = textureDropdown
+    innerY = LC.AnchorWidget(textureDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local borderColorPicker -- forward declare
+
+    local borderToggle = W.CreateToggle(content, {
+        label = L["Timer Bar Border"],
+        tooltip = L["Show a border around the timer bar"],
+        get = function()
+            return db.profile.rollFrame.timerBarBorder
+        end,
+        set = function(value)
+            db.profile.rollFrame.timerBarBorder = value
+            if borderColorPicker then
+                borderColorPicker:SetDisabled(not value)
             end
             NotifyRollManager()
         end,
     })
-    innerY = LC.AnchorWidget(compactToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    layoutWidgets[#layoutWidgets + 1] = borderToggle
+    innerY = LC.AnchorWidget(borderToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    borderColorPicker = W.CreateColorPicker(content, {
+        label = L["Timer Bar Border Color"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarBorderColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarBorderColor.r = r
+            db.profile.rollFrame.timerBarBorderColor.g = g
+            db.profile.rollFrame.timerBarBorderColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    borderColorPicker:SetDisabled(not db.profile.rollFrame.timerBarBorder)
+    layoutWidgets[#layoutWidgets + 1] = borderColorPicker
+    innerY = LC.AnchorWidget(borderColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local barColorPicker -- forward declare
+
+    local colorModeDropdown = W.CreateDropdown(content, {
+        label = L["Color Mode"],
+        values = COLOR_MODE_VALUES,
+        get = function()
+            return db.profile.rollFrame.timerBarColorMode
+        end,
+        set = function(value)
+            db.profile.rollFrame.timerBarColorMode = value
+            if barColorPicker then
+                barColorPicker:SetDisabled(value ~= "custom")
+            end
+            NotifyRollManager()
+        end,
+    })
+    layoutWidgets[#layoutWidgets + 1] = colorModeDropdown
+    innerY = LC.AnchorWidget(colorModeDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    barColorPicker = W.CreateColorPicker(content, {
+        label = L["Bar Color"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarColor.r = r
+            db.profile.rollFrame.timerBarColor.g = g
+            db.profile.rollFrame.timerBarColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    barColorPicker:SetDisabled(db.profile.rollFrame.timerBarColorMode ~= "custom")
+    layoutWidgets[#layoutWidgets + 1] = barColorPicker
+    innerY = LC.AnchorWidget(barColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local bgColorPicker = W.CreateColorPicker(content, {
+        label = L["Bar Background"],
+        hasAlpha = false,
+        get = function()
+            local c = db.profile.rollFrame.timerBarBackgroundColor
+            return c.r, c.g, c.b
+        end,
+        set = function(r, g, b)
+            db.profile.rollFrame.timerBarBackgroundColor.r = r
+            db.profile.rollFrame.timerBarBackgroundColor.g = g
+            db.profile.rollFrame.timerBarBackgroundColor.b = b
+            NotifyRollManager()
+        end,
+    })
+    layoutWidgets[#layoutWidgets + 1] = bgColorPicker
+    innerY = LC.AnchorWidget(bgColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local bgOpacitySlider = W.CreateSlider(content, {
+        label = L["Bar Background Opacity"],
+        min = 0,
+        max = 1,
+        step = 0.05,
+        isPercent = true,
+        format = "%.0f",
+        get = function()
+            return db.profile.rollFrame.timerBarBackgroundAlpha
+        end,
+        set = function(value)
+            db.profile.rollFrame.timerBarBackgroundAlpha = value
+            NotifyRollManager()
+        end,
+    })
+    layoutWidgets[#layoutWidgets + 1] = bgOpacitySlider
+    innerY = LC.AnchorWidget(bgOpacitySlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    reapplySubState[#reapplySubState + 1] = function()
+        local isMinimal = (db.profile.rollFrame.timerBarStyle == "minimal")
+        timerBarHeightSlider:SetDisabled(isMinimal)
+        minimalHeightSlider:SetDisabled(not isMinimal)
+        borderColorPicker:SetDisabled(not db.profile.rollFrame.timerBarBorder)
+        barColorPicker:SetDisabled(db.profile.rollFrame.timerBarColorMode ~= "custom")
+    end
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Section: Buttons (button size, spacing, frame spacing, content padding)
+-------------------------------------------------------------------------------
+
+local function CreateButtonsSection(parent, db, yOffset, layoutWidgets)
+    local section = W.CreateSection(parent, L["Buttons"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
+
+    innerY = CreateLayoutSlider(
+        content, db, innerY, L["Button Size"], L["Size of Need/Greed/Pass buttons"], "buttonSize", 16, 36, 1, "%d",
+        layoutWidgets
+    )
+    innerY = CreateLayoutSlider(
+        content, db, innerY, L["Button Spacing"], L["Spacing between roll buttons"], "buttonSpacing", 0, 12, 1, "%d",
+        layoutWidgets
+    )
+    innerY = CreateLayoutSlider(
+        content, db, innerY, L["Frame Spacing"], L["Spacing between multiple roll frames"], "frameSpacing", 0, 16, 1,
+        "%d", layoutWidgets
+    )
+    innerY = CreateLayoutSlider(
+        content, db, innerY, L["Content Padding"], L["Inner padding of the roll frame"], "contentPadding", 0, 12, 1,
+        "%d", layoutWidgets
+    )
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Section: Icon (position, side, offsets)
+-------------------------------------------------------------------------------
+
+local function CreateIconSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    local section = W.CreateSection(parent, L["Icon"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
 
     local iconOutsideGapSlider -- forward declared; assigned below
 
@@ -412,6 +573,7 @@ local function CreateLayoutSection(parent, db, yOffset)
             NotifyRollManager()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = iconPositionDropdown
     innerY = LC.AnchorWidget(iconPositionDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local iconSideDropdown = W.CreateDropdown(content, {
@@ -426,6 +588,7 @@ local function CreateLayoutSection(parent, db, yOffset)
             NotifyRollManager()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = iconSideDropdown
     innerY = LC.AnchorWidget(iconSideDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     iconOutsideGapSlider = W.CreateSlider(content, {
@@ -443,6 +606,7 @@ local function CreateLayoutSection(parent, db, yOffset)
         end,
     })
     iconOutsideGapSlider:SetDisabled(db.profile.rollFrame.iconPosition == "inside")
+    layoutWidgets[#layoutWidgets + 1] = iconOutsideGapSlider
     innerY = LC.AnchorWidget(iconOutsideGapSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local iconOffsetXSlider = W.CreateSlider(content, {
@@ -459,6 +623,7 @@ local function CreateLayoutSection(parent, db, yOffset)
             NotifyRollManager()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = iconOffsetXSlider
     innerY = LC.AnchorWidget(iconOffsetXSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local iconOffsetYSlider = W.CreateSlider(content, {
@@ -475,131 +640,12 @@ local function CreateLayoutSection(parent, db, yOffset)
             NotifyRollManager()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = iconOffsetYSlider
     innerY = LC.AnchorWidget(iconOffsetYSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local textureDropdown = W.CreateDropdown(content, {
-        label = L["Timer Bar Texture"],
-        values = function()
-            return LC.BuildLSMValues("statusbar")
-        end,
-        sort = true,
-        mediaType = "statusbar",
-        get = function()
-            return db.profile.rollFrame.timerBarTexture
-        end,
-        set = function(value)
-            db.profile.rollFrame.timerBarTexture = value
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(textureDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    -- Timer Bar Appearance sub-header (visual separator inside section)
-    local timerBarHeader = W.CreateHeader(content, L["Timer Bar Appearance"])
-    innerY = LC.AnchorWidget(timerBarHeader, content, innerY) - LC.SPACING_AFTER_HEADER
-
-    local borderColorPicker -- forward declare
-
-    local borderToggle = W.CreateToggle(content, {
-        label = L["Timer Bar Border"],
-        tooltip = L["Show a border around the timer bar"],
-        get = function()
-            return db.profile.rollFrame.timerBarBorder
-        end,
-        set = function(value)
-            db.profile.rollFrame.timerBarBorder = value
-            if borderColorPicker then
-                borderColorPicker:SetDisabled(not value)
-            end
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(borderToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    borderColorPicker = W.CreateColorPicker(content, {
-        label = L["Timer Bar Border Color"],
-        hasAlpha = false,
-        get = function()
-            local c = db.profile.rollFrame.timerBarBorderColor
-            return c.r, c.g, c.b
-        end,
-        set = function(r, g, b)
-            db.profile.rollFrame.timerBarBorderColor.r = r
-            db.profile.rollFrame.timerBarBorderColor.g = g
-            db.profile.rollFrame.timerBarBorderColor.b = b
-            NotifyRollManager()
-        end,
-    })
-    borderColorPicker:SetDisabled(not db.profile.rollFrame.timerBarBorder)
-    innerY = LC.AnchorWidget(borderColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    local barColorPicker -- forward declare
-
-    local colorModeDropdown = W.CreateDropdown(content, {
-        label = L["Color Mode"],
-        values = COLOR_MODE_VALUES,
-        get = function()
-            return db.profile.rollFrame.timerBarColorMode
-        end,
-        set = function(value)
-            db.profile.rollFrame.timerBarColorMode = value
-            if barColorPicker then
-                barColorPicker:SetDisabled(value ~= "custom")
-            end
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(colorModeDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    barColorPicker = W.CreateColorPicker(content, {
-        label = L["Bar Color"],
-        hasAlpha = false,
-        get = function()
-            local c = db.profile.rollFrame.timerBarColor
-            return c.r, c.g, c.b
-        end,
-        set = function(r, g, b)
-            db.profile.rollFrame.timerBarColor.r = r
-            db.profile.rollFrame.timerBarColor.g = g
-            db.profile.rollFrame.timerBarColor.b = b
-            NotifyRollManager()
-        end,
-    })
-    barColorPicker:SetDisabled(db.profile.rollFrame.timerBarColorMode ~= "custom")
-    innerY = LC.AnchorWidget(barColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    local bgColorPicker = W.CreateColorPicker(content, {
-        label = L["Bar Background"],
-        hasAlpha = false,
-        get = function()
-            local c = db.profile.rollFrame.timerBarBackgroundColor
-            return c.r, c.g, c.b
-        end,
-        set = function(r, g, b)
-            db.profile.rollFrame.timerBarBackgroundColor.r = r
-            db.profile.rollFrame.timerBarBackgroundColor.g = g
-            db.profile.rollFrame.timerBarBackgroundColor.b = b
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(bgColorPicker, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    local bgOpacitySlider = W.CreateSlider(content, {
-        label = L["Bar Background Opacity"],
-        min = 0,
-        max = 1,
-        step = 0.05,
-        isPercent = true,
-        format = "%.0f",
-        get = function()
-            return db.profile.rollFrame.timerBarBackgroundAlpha
-        end,
-        set = function(value)
-            db.profile.rollFrame.timerBarBackgroundAlpha = value
-            NotifyRollManager()
-        end,
-    })
-    innerY = LC.AnchorWidget(bgOpacitySlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    reapplySubState[#reapplySubState + 1] = function()
+        iconOutsideGapSlider:SetDisabled(db.profile.rollFrame.iconPosition == "inside")
+    end
 
     section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
@@ -608,7 +654,7 @@ local function CreateLayoutSection(parent, db, yOffset)
 end
 
 -------------------------------------------------------------------------------
--- Build the Loot Roll tab content
+-- Build the Roll Frame tab content
 -------------------------------------------------------------------------------
 
 local function CreateContent(parent)
@@ -616,8 +662,26 @@ local function CreateContent(parent)
     local db = dlns.Addon.db
     local yOffset = LC.PADDING_TOP
 
-    yOffset = CreateRollFrameSection(parent, db, yOffset)
-    yOffset = CreateLayoutSection(parent, db, yOffset)
+    local layoutWidgets = {}
+    local reapplySubState = {}
+
+    yOffset = CreateRollFrameSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    yOffset = CreateFrameSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    yOffset = CreateTimerBarSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+    yOffset = CreateButtonsSection(parent, db, yOffset, layoutWidgets)
+    yOffset = CreateIconSection(parent, db, yOffset, layoutWidgets, reapplySubState)
+
+    -- Apply initial disabled state
+    if not db.profile.rollFrame.enabled then
+        for _, widget in ipairs(layoutWidgets) do
+            widget:SetDisabled(true)
+        end
+    else
+        -- Apply sub-state even when enabled (e.g. compact mode, timer bar style)
+        for _, fn in ipairs(reapplySubState) do
+            fn()
+        end
+    end
 
     parent:SetHeight(math_abs(yOffset) + LC.PADDING_BOTTOM)
 end
@@ -628,7 +692,7 @@ end
 
 ns.Tabs[#ns.Tabs + 1] = {
     id = "lootRoll",
-    label = L["Loot Roll"],
+    label = L["Roll Frame"],
     order = 3,
     createFunc = CreateContent,
 }

--- a/DragonLoot_Options/Tabs/LootWindowTab.lua
+++ b/DragonLoot_Options/Tabs/LootWindowTab.lua
@@ -13,6 +13,7 @@ local L = ns.L
 -------------------------------------------------------------------------------
 
 local math_abs = math.abs
+local ipairs = ipairs
 
 -------------------------------------------------------------------------------
 -- DragonWidgets references
@@ -45,6 +46,7 @@ local function CreateContent(parent)
     dlns = ns.dlns
     local db = dlns.Addon.db
     local yOffset = LC.PADDING_TOP
+    local layoutWidgets = {}
 
     ---------------------------------------------------------------------------
     -- Section: Loot Window
@@ -63,6 +65,9 @@ local function CreateContent(parent)
         set = function(value)
             db.profile.lootWindow.enabled = value
             ApplyLootSettings()
+            for _, widget in ipairs(layoutWidgets) do
+                widget:SetDisabled(not value)
+            end
         end,
     })
     lootY = LC.AnchorWidget(enableToggle, lootContent, lootY) - LC.SPACING_BETWEEN_WIDGETS
@@ -78,6 +83,7 @@ local function CreateContent(parent)
             db.profile.lootWindow.lock = value
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = lockToggle
     lootY = LC.AnchorWidget(lockToggle, lootContent, lootY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Toggle: Position at Cursor
@@ -91,6 +97,7 @@ local function CreateContent(parent)
             db.profile.lootWindow.positionAtCursor = value
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = cursorToggle
     lootY = LC.AnchorWidget(cursorToggle, lootContent, lootY) - LC.SPACING_BETWEEN_WIDGETS
 
     lootSection:SetContentHeight(math_abs(lootY) + LC.SECTION_PADDING_BOTTOM)
@@ -117,6 +124,7 @@ local function CreateContent(parent)
             ApplyLootSettings()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = scaleSlider
     layoutY = LC.AnchorWidget(scaleSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Slider: Width
@@ -134,6 +142,7 @@ local function CreateContent(parent)
             ApplyLootSettings()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = widthSlider
     layoutY = LC.AnchorWidget(widthSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Slider: Height
@@ -151,6 +160,7 @@ local function CreateContent(parent)
             ApplyLootSettings()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = heightSlider
     layoutY = LC.AnchorWidget(heightSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Slider: Slot Spacing
@@ -168,6 +178,7 @@ local function CreateContent(parent)
             ApplyLootSettings()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = slotSpacingSlider
     layoutY = LC.AnchorWidget(slotSpacingSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     -- Slider: Content Padding
@@ -185,10 +196,20 @@ local function CreateContent(parent)
             ApplyLootSettings()
         end,
     })
+    layoutWidgets[#layoutWidgets + 1] = contentPaddingSlider
     layoutY = LC.AnchorWidget(contentPaddingSlider, layoutContent, layoutY) - LC.SPACING_BETWEEN_WIDGETS
 
     layoutSection:SetContentHeight(math_abs(layoutY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(layoutSection, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    ---------------------------------------------------------------------------
+    -- Apply initial disabled state
+    ---------------------------------------------------------------------------
+    if not db.profile.lootWindow.enabled then
+        for _, widget in ipairs(layoutWidgets) do
+            widget:SetDisabled(true)
+        end
+    end
 
     ---------------------------------------------------------------------------
     -- Set content height for scroll frame


### PR DESCRIPTION
## Summary

Redesigns the options UI across all tabs for a more natural, intuitive UX flow. Pure presentation changes - no config key names or defaults are modified.

### Changes

**Roll Frame tab (was "Loot Roll")**
- Renamed tab to "Roll Frame" to match user goals, not module name
- Split the overloaded "Layout" section into four focused sections: Frame (dimensions/scale), Timer Bar (style/colors/texture), Buttons (sizing/spacing), Icon (position/offsets)
- All layout sections contextually disabled when "Enable Custom Roll Frame" is off
- Sub-state correctly restored on re-enable (compact mode, timer bar style, border toggle, color mode, icon position)
- Lock Position and Hide After Voting now also disabled when roll frame is off

**Loot Window tab**
- Lock Position, Position at Cursor, and all Layout sliders contextually disabled when "Enable Custom Loot Window" is off

**History tab**
- Split into three sections: History (enable + auto show), Recording (track direct loot + min quality filter), Display (show roll details + layout sliders)
- Added missing Lock Position toggle for the history frame

**Auto-Loot tab**
- Renamed "Smart Auto-Loot" section header to "Settings" (less redundant with tab label)
- Minimum Quality dropdown contextually disabled when auto-loot is off

**Animation tab**
- Renamed "Animation" section header to "Global Settings" (less redundant with tab label)
- Duration sliders and all animation type dropdowns contextually disabled when animations are off

### Testing

- `luacheck .` passes with 0 new warnings
- Manual in-game test: open /dl config, verify each tab's disable behavior, section grouping, and label clarity

Closes #124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lock Position toggle to control history frame positioning.

* **Improvements**
  * Reorganized options UI with clearer section groupings across multiple tabs.
  * Enhanced control dependencies: related settings now properly enable/disable together based on parent toggles.
  * Improved labeling for better clarity (e.g., "Roll Frame" tab naming and "Global Settings" organization).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->