### PR TITLE
fix: prevent Blizzard roll frame showing alongside custom roll frame

### DIFF
--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -193,7 +193,7 @@ local function SuppressBlizzardRollFrames()
     -- after event unregistration; the boolean toggle controls whether it acts.
     if not rollFrameHooksInstalled then
         -- Post-hook GroupLootContainer_AddRoll (taint-safe, Classic nil guard)
-        if GroupLootContainer_AddRoll then
+        if _G.GroupLootContainer_AddRoll then
             hooksecurefunc("GroupLootContainer_AddRoll", function()
                 if suppressRollContainer then
                     if GroupLootContainer then GroupLootContainer:Hide() end
@@ -210,8 +210,7 @@ local function SuppressBlizzardRollFrames()
             local frame = _G["GroupLootFrame" .. i]
             if frame then
                 hooksecurefunc(frame, "Show", function(self)
-                    local db = ns.Addon.db and ns.Addon.db.profile
-                    if db and db.rollFrame and db.rollFrame.enabled then
+                    if suppressRollContainer then
                         self:Hide()
                     end
                 end)

--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -117,6 +117,8 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 end
 
 local lootFrameHooked = false
+local rollFrameHooksInstalled = false
+local suppressRollContainer = false
 
 -- Force-load the LoD addon that provides LootFrame (Retail: Blizzard_LootUI).
 -- Called before any suppression so LootFrame exists and can be hooked at
@@ -185,6 +187,41 @@ local function SuppressBlizzardRollFrames()
         GroupLootContainer:UnregisterAllEvents()
         GroupLootContainer:Hide()
     end
+
+    -- One-time hook installation (hooksecurefunc is permanent, so guard with a
+    -- flag that is never reset). The post-hook hides frames as belt-and-suspenders
+    -- after event unregistration; the boolean toggle controls whether it acts.
+    if not rollFrameHooksInstalled then
+        -- Post-hook GroupLootContainer_AddRoll (taint-safe, Classic nil guard)
+        if GroupLootContainer_AddRoll then
+            hooksecurefunc("GroupLootContainer_AddRoll", function()
+                if suppressRollContainer then
+                    if GroupLootContainer then GroupLootContainer:Hide() end
+                    for i = 1, 4 do
+                        local f = _G["GroupLootFrame" .. i]
+                        if f then f:Hide() end
+                    end
+                end
+            end)
+        end
+
+        -- Hook each GroupLootFrame Show() to re-hide when roll frame is active
+        for i = 1, 4 do
+            local frame = _G["GroupLootFrame" .. i]
+            if frame then
+                hooksecurefunc(frame, "Show", function(self)
+                    local db = ns.Addon.db and ns.Addon.db.profile
+                    if db and db.rollFrame and db.rollFrame.enabled then
+                        self:Hide()
+                    end
+                end)
+            end
+        end
+
+        rollFrameHooksInstalled = true
+    end
+
+    suppressRollContainer = true
 end
 
 local function RestoreBlizzardLootFrame()
@@ -219,6 +256,8 @@ local function RestoreBlizzardRollFrames()
         GroupLootContainer:RegisterEvent("START_LOOT_ROLL")
         GroupLootContainer:RegisterEvent("CANCEL_LOOT_ROLL")
     end
+
+    suppressRollContainer = false
 end
 
 -- Expose for use in other modules


### PR DESCRIPTION
## Summary

Blizzard's roll frame was appearing at the same time as DragonLoot's custom roll frame when a group loot roll fired.

## Root Cause

`SuppressBlizzardRollFrames()` unregistered events and hid frames on enable, but had no hook to prevent re-showing. `GroupLootContainer_AddRoll` (called by UIParent's `START_LOOT_ROLL` dispatch) could still fire and show frames via `GroupLootContainer_OpenNewFrame`. This was inconsistent with `SuppressBlizzardLootFrame()` which correctly installs a permanent `hooksecurefunc(LootFrame, "Show", ...)` guard.

## Changes

- Added `hooksecurefunc("GroupLootContainer_AddRoll", ...)` - taint-safe post-hook that hides the container and all 4 `GroupLootFrame` instances when suppression is active. Guarded with `if GroupLootContainer_AddRoll then` for Classic compatibility.
- Added `hooksecurefunc(frame, "Show", ...)` on each `GroupLootFrame1-4` as belt-and-suspenders, mirroring the existing `LootFrame:Show()` hook pattern.
- Split `rollFrameHooked` into `rollFrameHooksInstalled` (permanent, never reset) and `suppressRollContainer` (toggleable) to prevent hook accumulation across disable/re-enable cycles.

## Type of Change

- [x] Bug fix

## Testing

- `luacheck .` passes with 0 new warnings
- Tested suppress/restore cycle: Blizzard roll frames correctly suppressed when enabled, restored when disabled
- No taint errors in combat on Retail

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced roll frame visibility management to provide more reliable control over suppression and restoration of Blizzard's default roll interface during group loot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->