### PR TITLE
feat: detect ElvUI loot conflict and offer to disable (#147)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -22,7 +22,7 @@ read_globals = {
 
     -- WoW API - General
     "CreateFrame", "GetTime", "UIParent", "GameTooltip", "_G",
-    "PlaySound", "SOUNDKIT", "GetItemInfo", "C_Timer", "StaticPopup_Show",
+    "PlaySound", "SOUNDKIT", "GetItemInfo", "C_Timer", "StaticPopup_Show", "ReloadUI",
 
     -- Libraries
     "LibStub",

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -121,6 +121,11 @@ local defaults = {
             whitelist = {}, -- { [itemID] = true }
             blacklist = {}, -- { [itemID] = true }
         },
+
+        elvuiCompat = {
+            dismissed = false,
+            lastConflictSignature = "",
+        },
     },
 }
 
@@ -128,7 +133,7 @@ local defaults = {
 -- Profile Migration
 -------------------------------------------------------------------------------
 
-local CURRENT_SCHEMA = 2
+local CURRENT_SCHEMA = 3
 
 local function DeepCopyValue(value)
     if type(value) ~= "table" then

--- a/DragonLoot/Core/ElvUICompat.lua
+++ b/DragonLoot/Core/ElvUICompat.lua
@@ -215,6 +215,11 @@ StaticPopupDialogs["DRAGONLOOT_ELVUI_CONFLICT"] = {
     text = "", -- set dynamically before each show
     button1 = YES,
     button2 = NO,
+    -- StaticPopup frames are pooled; clear stale accept state so a reused
+    -- frame doesn't carry accepted=true from a previous dialog into OnHide.
+    OnShow = function(self)
+        self.accepted = nil
+    end,
     OnAccept = function(self, data)
         if not data then
             return

--- a/DragonLoot/Core/ElvUICompat.lua
+++ b/DragonLoot/Core/ElvUICompat.lua
@@ -1,0 +1,265 @@
+-------------------------------------------------------------------------------
+-- ElvUICompat.lua
+-- Detect ElvUI loot/roll conflicts and offer to disable + reload
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary, Cata, Classic
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+
+local C_AddOns = C_AddOns
+local IsAddOnLoaded = IsAddOnLoaded
+local StaticPopup_Show = StaticPopup_Show
+local StaticPopupDialogs = StaticPopupDialogs
+local ReloadUI = ReloadUI
+local YES, NO = YES, NO
+
+local L = ns.L
+
+ns.ElvUICompat = {}
+
+-------------------------------------------------------------------------------
+-- Locale keys (single source of truth: used as both L[...] lookup key and
+-- fallback when no translation is registered). Must match enUS.lua verbatim.
+-------------------------------------------------------------------------------
+
+local KEY_LOOT = "ElvUI's loot window is enabled and conflicts with DragonLoot."
+    .. " Disable ElvUI's loot modules and reload now?"
+local KEY_ROLL = "ElvUI's group-loot roll frames are enabled and conflict with DragonLoot."
+    .. " Disable ElvUI's roll frames and reload now?"
+local KEY_BOTH = "ElvUI's loot window and group-loot roll frames are enabled and conflict with DragonLoot."
+    .. " Disable both ElvUI modules and reload now?"
+
+local MESSAGES = {
+    ["loot+roll"] = KEY_BOTH,
+    ["loot"] = KEY_LOOT,
+    ["roll"] = KEY_ROLL,
+}
+
+-------------------------------------------------------------------------------
+-- Private helpers
+-------------------------------------------------------------------------------
+
+local function IsElvUILoaded()
+    if C_AddOns and C_AddOns.IsAddOnLoaded then
+        return C_AddOns.IsAddOnLoaded("ElvUI")
+    elseif IsAddOnLoaded then
+        return IsAddOnLoaded("ElvUI")
+    end
+    return false
+end
+
+--- Resolve ElvUI's core engine table.
+--- Returns the E table, or nil on any failure (ElvUI absent, not yet initialized,
+--- or an unexpected shape). Nil means "cannot determine - skip prompting".
+local function GetElvUI()
+    if not IsElvUILoaded() then
+        return nil
+    end
+    local ElvUIContainer = _G.ElvUI
+    if type(ElvUIContainer) ~= "table" then
+        return nil
+    end
+    local E = ElvUIContainer[1]
+    if type(E) ~= "table" then
+        return nil
+    end
+    if type(E.private) ~= "table" or type(E.private.general) ~= "table" then
+        return nil
+    end
+    return E
+end
+
+-------------------------------------------------------------------------------
+-- Public API
+-------------------------------------------------------------------------------
+
+function ns.ElvUICompat.IsPresent()
+    return GetElvUI() ~= nil
+end
+
+function ns.ElvUICompat.IsLootWindowActive()
+    local E = GetElvUI()
+    if not E then
+        return false
+    end
+    return E.private.general.loot == true
+end
+
+function ns.ElvUICompat.IsGroupLootActive()
+    local E = GetElvUI()
+    if not E then
+        return false
+    end
+    return E.private.general.lootRoll == true
+end
+
+--- Compute which DragonLoot features conflict with active ElvUI modules.
+--- Always returns a table - never nil - so callers can index without guarding.
+--- @param profile table DragonLoot AceDB profile (ns.Addon.db.profile)
+--- @return table conflicts { lootWindow = bool, rollFrame = bool }
+function ns.ElvUICompat.GetConflicts(profile)
+    local conflicts = { lootWindow = false, rollFrame = false }
+    if type(profile) ~= "table" then
+        return conflicts
+    end
+
+    local lootWindowEnabled = profile.lootWindow and profile.lootWindow.enabled == true
+    local rollFrameEnabled = profile.rollFrame and profile.rollFrame.enabled == true
+
+    if lootWindowEnabled and ns.ElvUICompat.IsLootWindowActive() then
+        conflicts.lootWindow = true
+    end
+    if rollFrameEnabled and ns.ElvUICompat.IsGroupLootActive() then
+        conflicts.rollFrame = true
+    end
+    return conflicts
+end
+
+--- Flip ElvUI's private flags for the requested modules. AceDB persists
+--- E.private to ElvPrivateDB automatically; we must NOT poke ElvPrivateDB directly.
+--- @param opts table { lootWindow = bool, rollFrame = bool }
+--- @return boolean changed true if any flag was flipped, false otherwise
+function ns.ElvUICompat.Disable(opts)
+    local E = GetElvUI()
+    if not E then
+        return false
+    end
+    if type(opts) ~= "table" then
+        return false
+    end
+
+    local changed = false
+    if opts.lootWindow and E.private.general.loot == true then
+        E.private.general.loot = false
+        changed = true
+    end
+    if opts.rollFrame and E.private.general.lootRoll == true then
+        E.private.general.lootRoll = false
+        changed = true
+    end
+    return changed
+end
+
+-------------------------------------------------------------------------------
+-- Conflict detection and prompt
+-------------------------------------------------------------------------------
+
+local function BuildSignature(conflicts)
+    if conflicts.lootWindow and conflicts.rollFrame then
+        return "loot+roll"
+    elseif conflicts.lootWindow then
+        return "loot"
+    elseif conflicts.rollFrame then
+        return "roll"
+    end
+    return ""
+end
+
+local function MessageForSignature(signature)
+    local key = MESSAGES[signature]
+    if not key then
+        return ""
+    end
+    return (L and L[key]) or key
+end
+
+local function CheckAndPrompt()
+    local addon = ns.Addon
+    if not addon or not addon.db or not addon.db.profile then
+        if ns.DebugPrint then
+            ns.DebugPrint("ElvUICompat: skipped check - addon or db not ready")
+        end
+        return
+    end
+    local profile = addon.db.profile
+
+    -- Ensure the compat sub-table exists (defensive - FillMissingDefaults should handle it).
+    if type(profile.elvuiCompat) ~= "table" then
+        profile.elvuiCompat = { dismissed = false, lastConflictSignature = "" }
+    end
+
+    local conflicts = ns.ElvUICompat.GetConflicts(profile)
+    local signature = BuildSignature(conflicts)
+
+    if signature == "" then
+        -- No active conflicts - clear any prior dismissal so future conflicts re-prompt.
+        profile.elvuiCompat.dismissed = false
+        profile.elvuiCompat.lastConflictSignature = ""
+        return
+    end
+
+    if profile.elvuiCompat.dismissed and profile.elvuiCompat.lastConflictSignature == signature then
+        return
+    end
+
+    local dialog = StaticPopupDialogs["DRAGONLOOT_ELVUI_CONFLICT"]
+    if not dialog then
+        return
+    end
+    dialog.text = MessageForSignature(signature)
+
+    local data = {
+        lootWindow = conflicts.lootWindow,
+        rollFrame = conflicts.rollFrame,
+        signature = signature,
+    }
+    StaticPopup_Show("DRAGONLOOT_ELVUI_CONFLICT", nil, nil, data)
+end
+
+-------------------------------------------------------------------------------
+-- StaticPopup registration
+-------------------------------------------------------------------------------
+
+StaticPopupDialogs["DRAGONLOOT_ELVUI_CONFLICT"] = {
+    text = "", -- set dynamically before each show
+    button1 = YES,
+    button2 = NO,
+    OnAccept = function(self, data)
+        if not data then
+            return
+        end
+        self.accepted = true
+        local changed = ns.ElvUICompat.Disable({
+            lootWindow = data.lootWindow,
+            rollFrame = data.rollFrame,
+        })
+        if changed then
+            ReloadUI()
+        end
+    end,
+    -- OnHide fires for every close path (button2 "No", ESC, frame hide);
+    -- OnCancel only fires for button2, so we persist dismissal here instead.
+    OnHide = function(self)
+        if self.accepted then
+            return
+        end
+        local data = self.data
+        if not data then
+            return
+        end
+        local profile = ns.Addon and ns.Addon.db and ns.Addon.db.profile
+        if profile and profile.elvuiCompat then
+            profile.elvuiCompat.dismissed = true
+            profile.elvuiCompat.lastConflictSignature = data.signature or ""
+        end
+    end,
+    timeout = 0,
+    whileDead = 1,
+    hideOnEscape = 1,
+    preferredIndex = 3,
+}
+
+-------------------------------------------------------------------------------
+-- Initialize (called from Addon:OnEnable)
+-------------------------------------------------------------------------------
+
+function ns.ElvUICompat.Initialize()
+    -- Defer by ~1s so ElvUI's own Initialize phase finishes populating E.private
+    -- before we read the loot/lootRoll flags.
+    if ns.Addon and ns.Addon.ScheduleTimer then
+        ns.Addon:ScheduleTimer(CheckAndPrompt, 1)
+    else
+        CheckAndPrompt()
+    end
+end

--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -335,6 +335,11 @@ function Addon:OnEnable()
             end
         end
     end
+
+    -- ElvUI loot-conflict check (prompts once if conflicts detected)
+    if ns.ElvUICompat and ns.ElvUICompat.Initialize then
+        ns.ElvUICompat.Initialize()
+    end
 end
 
 function Addon:OnDisable()

--- a/DragonLoot/DragonLoot.toc
+++ b/DragonLoot/DragonLoot.toc
@@ -35,6 +35,7 @@ Core\Config.lua
 Core\ConfigWindow.lua
 Core\MinimapIcon.lua
 Core\SlashCommands.lua
+Core\ElvUICompat.lua
 
 # Display (shared)
 Display\DisplayUtils.lua

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -59,6 +59,14 @@ L["Toggle on/off"] = true
 -- Core/ConfigWindow.lua
 L["DragonLoot_Options addon not found. Please ensure it is installed."] = true
 
+-- Core/ElvUICompat.lua
+L["ElvUI's loot window is enabled and conflicts with DragonLoot."
+    .. " Disable ElvUI's loot modules and reload now?"] = true
+L["ElvUI's group-loot roll frames are enabled and conflict with DragonLoot."
+    .. " Disable ElvUI's roll frames and reload now?"] = true
+L["ElvUI's loot window and group-loot roll frames are enabled and conflict with DragonLoot."
+    .. " Disable both ElvUI modules and reload now?"] = true
+
 -- Display/LootFrame.lua
 L["BoE"] = true
 L["BoP"] = true

--- a/spec/Config_spec.lua
+++ b/spec/Config_spec.lua
@@ -37,10 +37,10 @@ describe("Config", function()
             assert.are.equal(100, db.profile.history.maxEntries)
         end)
 
-        it("sets schemaVersion to 2", function()
+        it("sets schemaVersion to 3", function()
             local db = initWithSeed(ns, nil)
 
-            assert.are.equal(2, db.profile.schemaVersion)
+            assert.are.equal(3, db.profile.schemaVersion)
         end)
 
         it("has lootIconSize in a fresh profile", function()
@@ -141,10 +141,10 @@ describe("Config", function()
         end)
 
         it(
-            "copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v2)",
+            "copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v3)",
             function()
                 local db = initWithSeed(ns, {
-                    schemaVersion = 2,
+                    schemaVersion = 3,
                     appearance = {
                         iconSize = 48,
                         -- lootIconSize intentionally absent to test migration propagation
@@ -162,12 +162,12 @@ describe("Config", function()
     ---------------------------------------------------------------------------
 
     describe("schemaVersion", function()
-        it("is set to 2 after migration from version 0", function()
+        it("is set to 3 after migration from version 0", function()
             local db = initWithSeed(ns, {
                 -- schemaVersion intentionally missing (defaults to 0)
             })
 
-            assert.are.equal(2, db.profile.schemaVersion)
+            assert.are.equal(3, db.profile.schemaVersion)
         end)
     end)
 end)


### PR DESCRIPTION
Closes #147

## Type of change
- [x] New feature

## Summary
Adds a new `Core/ElvUICompat.lua` module that detects when ElvUI's loot window (`E.private.general.loot`) or group-loot roll frames (`E.private.general.lootRoll`) are active alongside DragonLoot. On detection, shows a StaticPopup offering to disable the ElvUI modules and `ReloadUI()`. Dismissal is persisted per-profile in `profile.elvuiCompat`, scoped by conflict signature so later re-enables of an ElvUI module re-prompt.

## Design notes
- ElvUI's loot module gates (`M:LoadLoot` / `M:LoadLootRoll`) are only checked at Initialize - runtime flag flips don't undo hooks. `ReloadUI()` is required.
- AceDB persists `E.private` to `ElvPrivateDB` automatically on logout - no direct SavedVariable mutation.
- Prompt is deferred 1 second via `ScheduleTimer` so ElvUI finishes its own Initialize first.
- Bumps `CURRENT_SCHEMA` from 2 to 3 so existing profiles backfill the new `elvuiCompat` sub-table via `FillMissingDefaults`.
- Only prompts when BOTH sides of a conflict are enabled (ElvUI's flag ON AND DragonLoot's matching feature ON).

## Testing
- `luacheck .` clean (only pre-existing Libs/ warnings)
- Manual verification matrix:
  - [ ] ElvUI not installed: no prompt, no errors
  - [ ] ElvUI installed but disabled in AddOn manager: no prompt
  - [ ] ElvUI active with both toggles on: prompt shows; YES disables both + reloads; post-reload no prompt
  - [ ] User declines (NO / ESC / X): no prompt on next login
  - [ ] User declined, then re-enables ElvUI's loot: prompt reappears (signature changed)
  - [ ] Only one side conflicting: prompt text reflects that single conflict

## Checklist
- [x] Code follows repo style (4-space indent, 120-char line limit, plain hyphens)
- [x] luacheck passes with 0 new warnings
- [x] Locale strings added to enUS.lua (other locales fall back silently)
- [x] No new dependencies
- [x] No breaking changes to existing SavedVariables (AceDB schema migration is additive)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ElvUI compatibility checks that detect conflicting loot window and roll frame features. Users receive a notification and can choose to automatically disable the conflicting modules with a UI reload.

* **Chores**
  * Updated configuration schema with automatic migration for existing player profiles.
  * Updated static analysis configuration for code validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->