### PR TITLE
feat: persist loot history across sessions (#104)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,7 @@ read_globals = {
     -- WoW API - General
     "CreateFrame", "GetTime", "UIParent", "GameTooltip", "_G",
     "PlaySound", "SOUNDKIT", "GetItemInfo", "C_Timer", "StaticPopup_Show", "ReloadUI",
+    "time",
 
     -- Libraries
     "LibStub",

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -127,13 +127,20 @@ local defaults = {
             lastConflictSignature = "",
         },
     },
+
+    char = {
+        history = {
+            entries = {},   -- persisted loot history entries; populated at runtime
+            schemaVersion = 4,
+        },
+    },
 }
 
 -------------------------------------------------------------------------------
 -- Profile Migration
 -------------------------------------------------------------------------------
 
-local CURRENT_SCHEMA = 3
+local CURRENT_SCHEMA = 4
 
 local function DeepCopyValue(value)
     if type(value) ~= "table" then
@@ -233,6 +240,11 @@ local function MigrateProfile(db)
             appearance.iconSize = nil
         end
     end
+
+    -- v3 -> v4: introduce db.char.history.entries for persistent loot history (issue #104).
+    -- No profile data needs transformation - the new char scope is added by AceDB's defaults
+    -- handling when InitializeDB passes the updated defaults table to AceDB:New. The schema
+    -- bump is recorded by the unconditional assignment to profile.schemaVersion below.
 
     profile.schemaVersion = CURRENT_SCHEMA
 end

--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -15,10 +15,12 @@ local CreateFrame = CreateFrame
 local GameTooltip = GameTooltip
 local UIParent = UIParent
 local GetTime = GetTime
+local time = time
 local RAID_CLASS_COLORS = RAID_CLASS_COLORS
 local HandleModifiedItemClick = HandleModifiedItemClick
 local IsShiftKeyDown = IsShiftKeyDown
 local math_floor = math.floor
+local math_abs = math.abs
 local string_format = string.format
 local tostring = tostring
 
@@ -82,6 +84,67 @@ ns.historyData = {}
 
 -- Forward declaration for RefreshHistory (used by OnEntryClick)
 local RefreshHistory
+
+-------------------------------------------------------------------------------
+-- Persistence helpers (db.char.history.entries)
+-------------------------------------------------------------------------------
+
+local function BuildDedupKey(entry)
+    if not entry then
+        return nil
+    end
+    local bucket = entry.wallTime and math_floor(entry.wallTime / 86400) or 0
+    if entry.dropKey then
+        return entry.dropKey .. "|" .. bucket
+    end
+    local link = entry.itemLink or "?"
+    local winner = entry.winner or "?"
+    return link .. "|" .. winner .. "|" .. bucket
+end
+
+ns.HistoryFrame_BuildDedupKey = BuildDedupKey
+
+local function PersistEntries()
+    local db = ns.Addon and ns.Addon.db
+    if not db or not db.char or not db.char.history then
+        return
+    end
+    local store = db.char.history.entries
+    if type(store) ~= "table" then
+        store = {}
+        db.char.history.entries = store
+    end
+    wipe(store)
+    for i, entry in ipairs(ns.historyData) do
+        store[i] = entry
+    end
+end
+
+local function LoadPersistedEntries()
+    local db = ns.Addon and ns.Addon.db
+    if not db or not db.char or not db.char.history then
+        return
+    end
+    local stored = db.char.history.entries
+    if type(stored) ~= "table" or #stored == 0 then
+        return
+    end
+
+    local maxEntries = (db.profile and db.profile.history and db.profile.history.maxEntries) or 100
+    local limit = #stored
+    if limit > maxEntries then
+        limit = maxEntries
+    end
+
+    wipe(ns.historyData)
+    for i = 1, limit do
+        ns.historyData[i] = stored[i]
+    end
+
+    if db.profile and db.profile.debug then
+        ns.DebugPrint("HistoryFrame loaded " .. #ns.historyData .. " persisted entries")
+    end
+end
 
 -------------------------------------------------------------------------------
 -- Backdrop and font wrappers (delegate to DisplayUtils)
@@ -168,13 +231,33 @@ end
 -- Time formatting helper
 -------------------------------------------------------------------------------
 
-local function FormatTimeAgo(timestamp)
-    if not timestamp then
+local function FormatTimeAgo(entry)
+    if not entry then
         return ""
     end
-    local elapsed = GetTime() - timestamp
-    if elapsed < 0 then
-        elapsed = 0
+
+    local sessionElapsed
+    if entry.timestamp then
+        sessionElapsed = GetTime() - entry.timestamp
+        if sessionElapsed < 0 then
+            sessionElapsed = nil
+        end
+    end
+
+    local wallElapsed
+    if entry.wallTime then
+        wallElapsed = time() - entry.wallTime
+        if wallElapsed < 0 then
+            wallElapsed = nil
+        end
+    end
+
+    local elapsed
+    if wallElapsed and sessionElapsed and math_abs(wallElapsed - sessionElapsed) > 300 then
+        -- Disagreement larger than 5 minutes: persisted entry from prior session. Trust wall clock.
+        elapsed = wallElapsed
+    else
+        elapsed = sessionElapsed or wallElapsed or 0
     end
 
     if elapsed < 60 then
@@ -353,6 +436,8 @@ local function ReleaseEntry(entry)
     entry:ClearAllPoints()
     entry.itemLink = nil
     entry.quality = nil
+    entry.timestamp = nil
+    entry.wallTime = nil
     entry._entryKey = nil
     entry._rollResults = nil
     entry.icon:SetTexture(nil)
@@ -480,7 +565,8 @@ end
 
 local function PopulateEntry(entry, data)
     entry.itemLink = data.itemLink
-    entry.timestampValue = data.timestamp
+    entry.timestamp = data.timestamp
+    entry.wallTime = data.wallTime
     entry.quality = data.quality
 
     -- Icon
@@ -537,7 +623,7 @@ local function PopulateEntry(entry, data)
     -- Time
     entry.timeText:SetFont(fontPath, fontSize - 2, fontOutline)
     DU.ApplyFontShadow(entry.timeText, ns.Addon.db)
-    entry.timeText:SetText(FormatTimeAgo(data.timestamp))
+    entry.timeText:SetText(FormatTimeAgo(data))
 
     -- Roll details expand/collapse
     local db = ns.Addon.db.profile
@@ -850,8 +936,8 @@ local function StartTimeRefresh()
             return
         end
         for _, entry in ipairs(activeEntries) do
-            if entry.timestampValue then
-                entry.timeText:SetText(FormatTimeAgo(entry.timestampValue))
+            if entry.timestamp or entry.wallTime then
+                entry.timeText:SetText(FormatTimeAgo(entry))
             end
         end
     end, TIME_REFRESH_INTERVAL)
@@ -877,6 +963,7 @@ function ns.HistoryFrame.Initialize()
     ApplyLayoutOffsets(containerFrame)
     ns.HistoryFrame.ApplySettings()
     RestoreFramePosition()
+    LoadPersistedEntries()
     ns.DebugPrint("HistoryFrame initialized")
 end
 
@@ -1002,6 +1089,8 @@ function ns.HistoryFrame.AddEntry(data)
         table.remove(ns.historyData)
     end
 
+    PersistEntries()
+
     -- Refresh display if visible
     if containerFrame and containerFrame:IsShown() then
         RefreshHistory()
@@ -1011,14 +1100,24 @@ end
 function ns.HistoryFrame.UpdateEntryByKey(dropKey, newData)
     for i, data in ipairs(ns.historyData) do
         if data.dropKey == dropKey then
+            -- Preserve the original first-observation wall clock so persisted
+            -- timestamps survive cross-session re-seeds. The drop happened when
+            -- we first saw it, not when the API replayed it back to us.
+            if data.wallTime and (not newData.wallTime or data.wallTime < newData.wallTime) then
+                newData.wallTime = data.wallTime
+            end
+            if data.timestamp and not newData.timestamp then
+                newData.timestamp = data.timestamp
+            end
             ns.historyData[i] = newData
+            PersistEntries()
             if containerFrame and containerFrame:IsShown() then
                 RefreshHistory()
             end
             return
         end
     end
-    -- Not found, treat as new
+    -- Not found, treat as new (AddEntry persists)
     ns.HistoryFrame.AddEntry(newData)
 end
 
@@ -1035,6 +1134,8 @@ function ns.HistoryFrame.SetEntries(entries)
         ns.historyData[i] = entry
     end
 
+    PersistEntries()
+
     -- Refresh display if visible
     if containerFrame and containerFrame:IsShown() then
         RefreshHistory()
@@ -1044,6 +1145,7 @@ end
 function ns.HistoryFrame.ClearHistory()
     wipe(expandedEntries)
     wipe(ns.historyData)
+    PersistEntries()
     if containerFrame and containerFrame:IsShown() then
         RefreshHistory()
     end

--- a/DragonLoot/Listeners/HistoryListener_Classic.lua
+++ b/DragonLoot/Listeners/HistoryListener_Classic.lua
@@ -22,6 +22,8 @@ end
 local C_LootHistory = C_LootHistory
 local GetItemInfo = GetItemInfo
 local GetTime = GetTime
+local time = time
+local table_sort = table.sort
 
 -------------------------------------------------------------------------------
 -- Shared listener utilities
@@ -45,13 +47,10 @@ local function RefreshFromAPI()
     if not C_LootHistory or not C_LootHistory.GetNumItems then
         return
     end
-    local numItems = C_LootHistory.GetNumItems()
-    if not numItems or numItems == 0 then
-        ns.HistoryFrame.SetEntries({})
-        return
-    end
+    local numItems = C_LootHistory.GetNumItems() or 0
 
     local now = GetTime()
+    local nowWall = time()
     local entries = {}
     for i = 1, numItems do
         local _, itemLink, numPlayers, isDone, winnerIdx, _, _ = C_LootHistory.GetItem(i)
@@ -96,9 +95,44 @@ local function RefreshFromAPI()
             rollType = rollType,
             roll = roll,
             timestamp = now,
+            wallTime = nowWall,
             isComplete = isDone,
             rollResults = rollResults,
         }
+    end
+
+    -- Merge persisted entries that the API does not know about.
+    -- C_LootHistory in classic clients is volatile across sessions; without this
+    -- merge a SetEntries() call would wipe restored history. Build a dedup-key
+    -- set from the API entries and append any persisted entry whose key is not
+    -- already represented.
+    local buildKey = ns.HistoryFrame_BuildDedupKey
+    if buildKey and ns.historyData then
+        local apiKeys = {}
+        for _, entry in ipairs(entries) do
+            local key = buildKey(entry)
+            if key then
+                apiKeys[key] = true
+            end
+        end
+        for _, persisted in ipairs(ns.historyData) do
+            local key = buildKey(persisted)
+            if key and not apiKeys[key] then
+                entries[#entries + 1] = persisted
+                apiKeys[key] = true
+            end
+        end
+
+        table_sort(entries, function(a, b)
+            local at = a.wallTime or a.timestamp or 0
+            local bt = b.wallTime or b.timestamp or 0
+            return at > bt
+        end)
+
+        local maxEntries = (ns.Addon and ns.Addon.db and ns.Addon.db.profile.history.maxEntries) or 100
+        while #entries > maxEntries do
+            entries[#entries] = nil
+        end
     end
 
     ns.HistoryFrame.SetEntries(entries)
@@ -182,6 +216,11 @@ local function OnAutoShow()
     ns.DebugPrint("LOOT_HISTORY_AUTO_SHOW")
 end
 
+-- LOOT_HISTORY_CLEAR_HISTORY in classic clients is unreliable and not all clients fire it.
+-- We deliberately do NOT clear ns.historyData or the persisted store here. Persisted history is
+-- only wiped via explicit user action (HistoryFrame.ClearHistory or the options-tab Clear button).
+-- The next RefreshFromAPI will reconcile against the now-empty C_LootHistory by adding only
+-- whatever the API still returns - persisted entries remain visible to the user.
 local function OnHistoryClear()
     wipe(notifiedRollResults)
     ns.DebugPrint("LOOT_HISTORY_CLEAR_HISTORY (Classic)")

--- a/DragonLoot/Listeners/HistoryListener_Classic.lua
+++ b/DragonLoot/Listeners/HistoryListener_Classic.lua
@@ -101,6 +101,29 @@ local function RefreshFromAPI()
         }
     end
 
+    -- Carry forward persisted wallTime for drops we already saw on a prior day.
+    -- Without this, a drop persisted yesterday (yesterday's wallTime bucket) and
+    -- re-observed today (nowWall = today's bucket) produces two distinct dedup
+    -- keys, leaving a cross-midnight duplicate after the merge below.
+    if ns.historyData and #entries > 0 then
+        local persistedWallTime = {}
+        for _, persisted in ipairs(ns.historyData) do
+            if persisted.wallTime then
+                local link = persisted.itemLink or "?"
+                local winner = persisted.winner or "?"
+                persistedWallTime[link .. "|" .. winner] = persisted.wallTime
+            end
+        end
+        for _, entry in ipairs(entries) do
+            local link = entry.itemLink or "?"
+            local winner = entry.winner or "?"
+            local prior = persistedWallTime[link .. "|" .. winner]
+            if prior and (not entry.wallTime or prior < entry.wallTime) then
+                entry.wallTime = prior
+            end
+        end
+    end
+
     -- Merge persisted entries that the API does not know about.
     -- C_LootHistory in classic clients is volatile across sessions; without this
     -- merge a SetEntries() call would wipe restored history. Build a dedup-key
@@ -129,7 +152,11 @@ local function RefreshFromAPI()
             return at > bt
         end)
 
-        local maxEntries = (ns.Addon and ns.Addon.db and ns.Addon.db.profile.history.maxEntries) or 100
+        local maxEntries = (ns.Addon
+            and ns.Addon.db
+            and ns.Addon.db.profile
+            and ns.Addon.db.profile.history
+            and ns.Addon.db.profile.history.maxEntries) or 100
         while #entries > maxEntries do
             entries[#entries] = nil
         end

--- a/DragonLoot/Listeners/HistoryListener_Retail.lua
+++ b/DragonLoot/Listeners/HistoryListener_Retail.lua
@@ -22,6 +22,7 @@ end
 local C_LootHistory = C_LootHistory
 local GetItemInfo = GetItemInfo
 local GetTime = GetTime
+local time = time
 
 -------------------------------------------------------------------------------
 -- Shared listener utilities
@@ -166,6 +167,7 @@ local function ProcessDrop(encounterID, drop)
         rollType = leader and ConvertRollState(leader.state) or nil,
         roll = leader and leader.roll or nil,
         timestamp = GetTime(),
+        wallTime = time(),
         isComplete = drop.allPassed or (winner ~= nil),
         encounterID = encounterID,
         dropKey = dropKey,
@@ -219,6 +221,23 @@ local function OnHistoryClear()
 end
 
 -------------------------------------------------------------------------------
+-- Seed processedDrops from already-persisted entries so the API re-seed via
+-- PopulateExistingHistory does not duplicate entries we restored from
+-- SavedVariables. Persisted entries carry the same dropKey we generate here.
+-------------------------------------------------------------------------------
+
+local function SeedProcessedFromPersisted()
+    if not ns.historyData then
+        return
+    end
+    for _, entry in ipairs(ns.historyData) do
+        if entry.dropKey then
+            processedDrops[entry.dropKey] = true
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Populate existing history on load
 -------------------------------------------------------------------------------
 
@@ -252,6 +271,7 @@ function ns.HistoryListener.Initialize(addonRef)
     addon:RegisterEvent("LOOT_HISTORY_CLEAR_HISTORY", OnHistoryClear)
 
     isInitializing = true
+    SeedProcessedFromPersisted()
     PopulateExistingHistory()
     isInitializing = false
 

--- a/DragonLoot/Listeners/LootHistoryChat.lua
+++ b/DragonLoot/Listeners/LootHistoryChat.lua
@@ -12,6 +12,7 @@ local _, ns = ...
 -------------------------------------------------------------------------------
 
 local GetTime = GetTime
+local time = time
 local UnitName = UnitName
 local UnitClass = UnitClass
 local GetPlayerInfoByGUID = GetPlayerInfoByGUID
@@ -179,6 +180,7 @@ local function AddLootEntry(playerName, playerClass, itemLink, _)
         rollType = nil,
         roll = nil,
         timestamp = GetTime(),
+        wallTime = time(),
         isComplete = true,
         isDirectLoot = true,
     }

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -265,6 +265,8 @@ L["Track items you pick up directly (not from a loot window)"] = true
 L["Roll Details"] = true
 L["Show Roll Details"] = true
 L["Click history entries to expand and see all player rolls"] = true
+L["Permanently delete all stored loot history entries"] = true
+L["Are you sure you want to clear all loot history? This cannot be undone."] = true
 
 -- DragonLoot_Options/Tabs/AutoLootTab.lua
 L["Settings"] = true

--- a/DragonLoot_Options/Tabs/HistoryTab.lua
+++ b/DragonLoot_Options/Tabs/HistoryTab.lua
@@ -15,6 +15,10 @@ local L = ns.L
 local math_abs = math.abs
 local tostring = tostring
 local tonumber = tonumber
+local StaticPopup_Show = StaticPopup_Show
+local StaticPopupDialogs = StaticPopupDialogs
+local YES = YES
+local NO = NO
 
 -------------------------------------------------------------------------------
 -- DragonWidgets references
@@ -28,6 +32,27 @@ local LC = ns.DW.LayoutConstants
 -------------------------------------------------------------------------------
 
 local dlns
+
+-------------------------------------------------------------------------------
+-- Static popup dialogs (defined at file scope)
+-------------------------------------------------------------------------------
+
+StaticPopupDialogs["DRAGONLOOT_CLEAR_HISTORY"] = {
+    text = L["Are you sure you want to clear all loot history? This cannot be undone."],
+    button1 = YES,
+    button2 = NO,
+    OnAccept = function()
+        local dl = ns.dlns
+        if not dl or not dl.HistoryFrame or not dl.HistoryFrame.ClearHistory then
+            return
+        end
+        dl.HistoryFrame.ClearHistory()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
 
 -------------------------------------------------------------------------------
 -- Helper: call HistoryFrame.ApplySettings if available
@@ -215,6 +240,18 @@ local function CreateDisplaySection(parent, db, yOffset)
         end,
     })
     innerY = LC.AnchorWidget(contentPaddingSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    -- Clear History button (destructive action)
+    local clearBtn = W.CreateButton(content, {
+        text = L["Clear History"],
+        width = 160,
+        tooltip = L["Permanently delete all stored loot history entries"],
+        onClick = function()
+            StaticPopup_Show("DRAGONLOOT_CLEAR_HISTORY")
+        end,
+    })
+    clearBtn:SetPoint("TOPLEFT", content, "TOPLEFT", LC.PADDING_SIDE, innerY)
+    innerY = innerY - clearBtn:GetHeight() - LC.SPACING_BETWEEN_WIDGETS
 
     section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
     yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS

--- a/spec/Config_spec.lua
+++ b/spec/Config_spec.lua
@@ -37,10 +37,11 @@ describe("Config", function()
             assert.are.equal(100, db.profile.history.maxEntries)
         end)
 
-        it("sets schemaVersion to 3", function()
+        it("sets schemaVersion to current schema", function()
             local db = initWithSeed(ns, nil)
 
-            assert.are.equal(3, db.profile.schemaVersion)
+            -- Keep in sync with CURRENT_SCHEMA in DragonLoot/Core/Config.lua
+            assert.are.equal(4, db.profile.schemaVersion)
         end)
 
         it("has lootIconSize in a fresh profile", function()
@@ -141,10 +142,13 @@ describe("Config", function()
         end)
 
         it(
-            "copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at schema v3)",
+            "copies iconSize to lootIconSize when lootIconSize is absent (skips FillMissingDefaults at current schema)",
             function()
                 local db = initWithSeed(ns, {
-                    schemaVersion = 3,
+                    -- Seed at current schema so FillMissingDefaults is skipped and the
+                    -- (unconditional) iconSize-split migration can propagate iconSize=48.
+                    -- Keep in sync with CURRENT_SCHEMA in DragonLoot/Core/Config.lua.
+                    schemaVersion = 4,
                     appearance = {
                         iconSize = 48,
                         -- lootIconSize intentionally absent to test migration propagation
@@ -162,12 +166,13 @@ describe("Config", function()
     ---------------------------------------------------------------------------
 
     describe("schemaVersion", function()
-        it("is set to 3 after migration from version 0", function()
+        it("is set to current schema after migration from version 0", function()
             local db = initWithSeed(ns, {
                 -- schemaVersion intentionally missing (defaults to 0)
             })
 
-            assert.are.equal(3, db.profile.schemaVersion)
+            -- Keep in sync with CURRENT_SCHEMA in DragonLoot/Core/Config.lua
+            assert.are.equal(4, db.profile.schemaVersion)
         end)
     end)
 end)


### PR DESCRIPTION
## Description

Loot history now persists to `db.char.history.entries` so it survives `/reload`, relog, and `LOOT_HISTORY_CLEAR_HISTORY` events. Entries stamp both an in-session `timestamp` and an absolute `wallTime`; `FormatTimeAgo` prefers wall-clock when session and wall disagree by more than 5 minutes (i.e. cross-session entries).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Closes #104.

## Testing

- [x] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [ ] WoW version(s) tested on: Retail, Classic

## Screenshots

- N/A

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [x] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow conventional commit format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loot history now persists per character across game sessions
  * Improved history time display with more accurate timestamps
  * Added "Clear History" option with confirmation dialog to permanently remove all stored entries

* **Chores**
  * Updated linter configuration and added new locale strings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->