### PR TITLE
feat: pending highest roller and hover tooltips for loot history (#90)

### DIFF
--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -22,6 +22,7 @@ local IsShiftKeyDown = IsShiftKeyDown
 local math_floor = math.floor
 local math_abs = math.abs
 local string_format = string.format
+local table_sort = table.sort
 local tostring = tostring
 
 local L = ns.L
@@ -310,6 +311,13 @@ local function CreateEntryFrame()
     entry.winnerName:SetJustifyH("LEFT")
     entry.winnerName:SetWordWrap(false)
 
+    -- Pending highest roller (occupies the same slot as winnerName, never both visible)
+    entry.pendingText = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    entry.pendingText:SetPoint("BOTTOMLEFT", entry.icon, "BOTTOMRIGHT", 4, 1)
+    entry.pendingText:SetJustifyH("LEFT")
+    entry.pendingText:SetWordWrap(false)
+    entry.pendingText:Hide()
+
     -- Roll info (e.g. "Need 87")
     entry.rollInfo = entry:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     entry.rollInfo:SetPoint("LEFT", entry.winnerName, "RIGHT", 6, 0)
@@ -443,6 +451,8 @@ local function ReleaseEntry(entry)
     entry.icon:SetTexture(nil)
     entry.itemName:SetText("")
     entry.winnerName:SetText("")
+    entry.pendingText:SetText("")
+    entry.pendingText:Hide()
     entry.rollInfo:SetText("")
     entry.timeText:SetText("")
     if entry.expandIndicator then
@@ -466,11 +476,45 @@ end
 -------------------------------------------------------------------------------
 
 local function OnEntryEnter(self)
-    if self.itemLink then
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:SetHyperlink(self.itemLink)
-        GameTooltip:Show()
+    if not self.itemLink then return end
+
+    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    GameTooltip:SetHyperlink(self.itemLink)
+
+    local rollResults = self._rollResults
+    if rollResults and #rollResults > 0 then
+        -- Build a sorted copy: highest non-pass roll first, then passes at the bottom.
+        local sorted = {}
+        for i = 1, #rollResults do
+            sorted[i] = rollResults[i]
+        end
+        table_sort(sorted, function(a, b)
+            local aPass = (a.rollType == 0) or not a.roll
+            local bPass = (b.rollType == 0) or not b.roll
+            if aPass ~= bPass then
+                return not aPass  -- non-pass first
+            end
+            return (a.roll or 0) > (b.roll or 0)
+        end)
+
+        GameTooltip:AddLine(" ")
+        GameTooltip:AddLine(L["Rolls:"], 1, 0.82, 0)
+
+        for i = 1, #sorted do
+            local result = sorted[i]
+            local cr, cg, cb = GetClassColor(result.playerClass)
+            local typeName = ns.RollTypeNames and ns.RollTypeNames[result.rollType] or L["Unknown"]
+            local rightText
+            if result.rollType == 0 or not result.roll then
+                rightText = typeName
+            else
+                rightText = string_format("%d (%s)", result.roll, typeName)
+            end
+            GameTooltip:AddDoubleLine(result.playerName or "?", rightText, cr, cg, cb, 1, 1, 1)
+        end
     end
+
+    GameTooltip:Show()
 end
 
 local function OnEntryLeave()
@@ -594,15 +638,52 @@ local function PopulateEntry(entry, data)
     end
     entry.itemName:SetTextColor(qr, qg, qb)
 
-    -- Winner name (class colored)
+    -- Winner name (class colored) OR pending highest roller
     entry.winnerName:SetFont(fontPath, fontSize - 2, fontOutline)
     DU.ApplyFontShadow(entry.winnerName, ns.Addon.db)
+    entry.pendingText:SetFont(fontPath, fontSize - 2, fontOutline)
+    DU.ApplyFontShadow(entry.pendingText, ns.Addon.db)
+
     if data.winner then
+        -- Resolved: show class-colored winner, hide pending text
         local cr, cg, cb = GetClassColor(data.winnerClass)
         entry.winnerName:SetText(data.winner)
         entry.winnerName:SetTextColor(cr, cg, cb)
+        entry.winnerName:Show()
+        entry.pendingText:Hide()
     else
+        -- In progress or no winner: show pending leader (if any rolls), hide winnerName
         entry.winnerName:SetText("")
+        entry.winnerName:Hide()
+
+        local leaderName, leaderClass, leaderRoll = nil, nil, nil
+        if data.rollResults then
+            for _, result in ipairs(data.rollResults) do
+                -- Skip Pass (rollType 0); look for highest non-pass roll
+                if result.rollType and result.rollType ~= 0 and result.roll then
+                    if not leaderRoll or result.roll > leaderRoll then
+                        leaderName = result.playerName
+                        leaderClass = result.playerClass
+                        leaderRoll = result.roll
+                    end
+                end
+            end
+        end
+
+        if leaderName and leaderRoll then
+            local cr, cg, cb = GetClassColor(leaderClass)
+            entry.pendingText:SetText(string_format(L["Highest: %s (%d)"], leaderName, leaderRoll))
+            entry.pendingText:SetTextColor(cr, cg, cb)
+            entry.pendingText:Show()
+        elseif data.rollResults and #data.rollResults > 0 then
+            -- All passes - rare but possible
+            entry.pendingText:SetText(L["(waiting on rolls)"])
+            entry.pendingText:SetTextColor(0.6, 0.6, 0.6)
+            entry.pendingText:Show()
+        else
+            -- No roll data yet (very early in event flow, or direct loot)
+            entry.pendingText:Hide()
+        end
     end
 
     -- Roll info
@@ -1041,6 +1122,8 @@ function ns.HistoryFrame.ApplySettings()
             DU.ApplyFontShadow(entry.itemName, ns.Addon.db)
             entry.winnerName:SetFont(fontPath, fontSize - 2, fontOutline)
             DU.ApplyFontShadow(entry.winnerName, ns.Addon.db)
+            entry.pendingText:SetFont(fontPath, fontSize - 2, fontOutline)
+            DU.ApplyFontShadow(entry.pendingText, ns.Addon.db)
             entry.rollInfo:SetFont(fontPath, fontSize - 2, fontOutline)
             DU.ApplyFontShadow(entry.rollInfo, ns.Addon.db)
             entry.timeText:SetFont(fontPath, fontSize - 2, fontOutline)

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -128,9 +128,12 @@ L["The gap in pixels between the icon and the frame border when the icon is outs
 L["%dh ago"] = true
 L["%dm ago"] = true
 L["%ds ago"] = true
+L["(waiting on rolls)"] = true
 L["Clear History"] = true
 L["DragonLoot - Loot History"] = true
+L["Highest: %s (%d)"] = true
 L["Looted"] = true
+L["Rolls:"] = true
 L["Unknown Item"] = true
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Closes #90

Adds three improvements to the loot history frame:

1. **Pending highest roller**: While a roll is in progress, the entry shows the current highest roller in their class color, formatted `Highest: PlayerName (87)`. When the roll resolves, this is replaced by the class-colored winner name as before. If all current rolls are passes, the entry shows `(waiting on rolls)` in grey.

2. **Hover tooltip with roll details**: Hovering a history entry now shows the standard item tooltip (unchanged) plus an appended `Rolls:` section listing every roll, sorted highest non-pass first, then passes at the bottom. Each row shows the player name in their class color and the roll value with type (`87 (Need)`) on the right.

3. **Item tooltip on icon hover**: The existing entry-wide hover already covers the icon area. No separate code path was needed; the same combined tooltip is shown whether the cursor is over the icon or anywhere else on the row.

Click-to-expand inline detail rows (governed by `db.profile.history.showRollDetails`) is preserved unchanged - both interactions now coexist.

## Type of change
- [x] New feature

## How has this been tested?
- `luacheck .` passes with 0 new warnings (31 pre-existing in `Libs/DragonWidgets/`).
- Manual verification recommended: trigger a group roll and confirm "Highest" updates as players roll in, then resolves to the winner name; hover the entry and confirm the tooltip shows item info plus a sorted roll breakdown.

## Checklist
- [x] My code follows the project's style guidelines (4-space indent, no tabs, 120-char limit, plain hyphens only)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (locale strings added)
- [x] My changes generate no new warnings
- [x] Click-to-expand behavior preserved (no regression)

## Affected versions
- [x] Retail
- [x] TBC Anniversary Classic
- [x] MoP Classic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History entries now display pending roll status while awaiting results
  * Enhanced tooltips show sorted roll results with highest rolls first, followed by passes
  * Class-colored per-player roll details appear in tooltip display
  * UI dynamically shows pending leader during rolling, switching to final winner when complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->