### PR TITLE
fix: show loot window for unlootable items during auto-loot (#158)

### DIFF
--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -876,22 +876,28 @@ end
 
 function ns.LootFrame.Show(autoLoot)
     if not containerFrame then
-        return
+        return false
     end
 
     ReleaseAllSlots()
 
     local numItems = GetNumLootItems()
     if numItems == 0 then
-        return
+        return false
     end
 
-    -- Auto-loot: skip UI entirely
+    -- Engine auto-loot: loot every slot in reverse (preserves lower indices),
+    -- then re-read the loot session. Items the client cannot auto-loot
+    -- (group rolls, BoP confirms, dungeon chests) remain and need the UI.
     if autoLoot then
-        for i = 1, numItems do
+        for i = numItems, 1, -1 do
             LootSlot(i)
         end
-        return
+        numItems = GetNumLootItems()
+        if numItems == 0 then
+            return false
+        end
+        -- Fall through to populate / layout / show UI for remaining items
     end
 
     -- Smart auto-loot: evaluate each slot and auto-pick qualifying items
@@ -912,7 +918,7 @@ function ns.LootFrame.Show(autoLoot)
             for i = 1, numItems do
                 LootSlot(i)
             end
-            return
+            return false
         end
 
         -- Some qualify: loot them in reverse order (preserves lower indices)
@@ -924,12 +930,12 @@ function ns.LootFrame.Show(autoLoot)
             -- Re-read numItems since some were looted
             numItems = GetNumLootItems()
             if numItems == 0 then
-                return
+                return false
             end
         end
     end
 
-    -- Only acquire and populate slots when NOT auto-looting
+    -- Populate UI for items that remain in the loot session
     for i = 1, numItems do
         local icon = GetNormalizedSlotInfo(i)
         if icon then
@@ -957,6 +963,7 @@ function ns.LootFrame.Show(autoLoot)
 
     -- Animate or just show
     ShowWithAnimation()
+    return true
 end
 
 function ns.LootFrame.Hide()

--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -821,8 +821,22 @@ function ns.LootFrame.Shutdown()
 end
 
 -------------------------------------------------------------------------------
--- Smart Auto-Loot Evaluation
+-- Auto-Loot Helpers
 -------------------------------------------------------------------------------
+
+-- Loots each slot in `indices` in reverse order, then returns the post-loot
+-- count from GetNumLootItems(). Reverse iteration preserves the meaning of
+-- lower indices: LootSlot shifts the loot session after each successful pick,
+-- so consuming from the high end keeps the unprocessed indices stable. Both
+-- call sites in ns.LootFrame.Show build `indices` in ascending order by
+-- construction (sequential `for` loops), which is the precondition this
+-- helper relies on.
+local function LootSlotsAndRecount(indices)
+    for i = #indices, 1, -1 do
+        LootSlot(indices[i])
+    end
+    return GetNumLootItems()
+end
 
 local function EvaluateSlot(slotIndex)
     local db = ns.Addon.db
@@ -886,49 +900,44 @@ function ns.LootFrame.Show(autoLoot)
         return false
     end
 
-    -- Engine auto-loot: loot every slot in reverse (preserves lower indices),
-    -- then re-read the loot session. Items the client cannot auto-loot
-    -- (group rolls, BoP confirms, dungeon chests) remain and need the UI.
+    -- Engine auto-loot: Blizzard's flag asked us to grab everything. Build the
+    -- full index set, hand it to the shared helper, and fall through with
+    -- whatever the client refused to auto-loot (group rolls, BoP confirms,
+    -- dungeon chests).
     if autoLoot then
-        for i = numItems, 1, -1 do
-            LootSlot(i)
+        local indices = {}
+        for i = 1, numItems do
+            indices[i] = i
         end
-        numItems = GetNumLootItems()
+        numItems = LootSlotsAndRecount(indices)
         if numItems == 0 then
             return false
         end
         -- Fall through to populate / layout / show UI for remaining items
     end
 
-    -- Smart auto-loot: evaluate each slot and auto-pick qualifying items
+    -- Smart auto-loot: evaluate each remaining slot against the user's filter,
+    -- collect the qualifying indices, and hand them to the same helper. If
+    -- every slot qualified, loot them all and skip the UI; otherwise fall
+    -- through with the rest.
     local db = ns.Addon.db
     if db and db.profile.autoLoot and db.profile.autoLoot.enabled then
         local qualifying = {}
-        local allQualify = true
         for i = 1, numItems do
             if EvaluateSlot(i) then
                 qualifying[#qualifying + 1] = i
-            else
-                allQualify = false
             end
         end
 
         -- All qualify: loot everything, skip UI entirely
-        if allQualify and #qualifying > 0 then
-            for i = 1, numItems do
-                LootSlot(i)
-            end
+        if #qualifying == numItems then
+            LootSlotsAndRecount(qualifying)
             return false
         end
 
-        -- Some qualify: loot them in reverse order (preserves lower indices)
+        -- Some qualify: loot them and fall through with the remainder
         if #qualifying > 0 then
-            for i = #qualifying, 1, -1 do
-                LootSlot(qualifying[i])
-            end
-            -- Fall through to show UI for remaining items
-            -- Re-read numItems since some were looted
-            numItems = GetNumLootItems()
+            numItems = LootSlotsAndRecount(qualifying)
             if numItems == 0 then
                 return false
             end

--- a/DragonLoot/Listeners/LootListener_Classic.lua
+++ b/DragonLoot/Listeners/LootListener_Classic.lua
@@ -38,11 +38,12 @@ local function OnLootOpened(_, autoLoot)
 
     isLootOpen = true
     ns.SuppressBlizzardLootFrame()
-    ns.LootFrame.Show(autoLoot)
+    local shown = ns.LootFrame.Show(autoLoot)
 
-    -- Only suppress DragonToast when the loot frame is actually visible.
-    -- Auto-loot returns early from Show() without displaying UI.
-    if not autoLoot then
+    -- Only suppress DragonToast when the loot window is actually visible.
+    -- With auto-loot enabled, Show() may still display the window for items
+    -- the engine cannot auto-loot (rolls, BoP confirms, dungeon chests).
+    if shown then
         ns.Addon:SendMessage("DRAGONTOAST_SUPPRESS", "DragonLoot")
     end
     ns.DebugPrint("LOOT_OPENED fired (Classic)")


### PR DESCRIPTION
Fixes #158.

## Problem

On Classic flavors (TBC Anniversary, Cata Classic, MoP Classic, Era), when the WoW client's built-in **Auto Loot** setting is enabled, `LOOT_OPENED` fires with `autoLoot=true` and DragonLoot's custom window never appears — even for items the engine **cannot** auto-loot: group-loot rolls, BoP confirmations, dungeon-boss/chest loot. The Blizzard frame is suppressed by DragonLoot, so the player sees nothing and the loot session ends silently when they move away.

User-confirmed repro from #158:
- Auto-loot ON + trash mob → correct (no window, items go straight to bags).
- Auto-loot ON + dungeon boss / chest with rolls → BUG (window never opens; rollable items lost when session closes).
- Auto-loot OFF → window works correctly.

## Root cause

`ns.LootFrame.Show(autoLoot)` in `DragonLoot/Display/LootFrame.lua` looped `LootSlot(i)` for every slot when `autoLoot == true` and then unconditionally `return`ed without ever re-checking `GetNumLootItems()`. Items the engine couldn't loot remained in the session, but DragonLoot had already exited and Blizzard's frame was suppressed.

The "smart auto-loot" branch immediately below already had the right pattern: loot what qualifies, re-read item count, fall through to UI if any remain. The engine-auto-loot path now mirrors that pattern.

## Changes

- **`Display/LootFrame.lua`** — `ns.LootFrame.Show` loops `LootSlot` in reverse for engine auto-loot, then re-reads `GetNumLootItems()` and falls through to the populate/layout/animate path when items remain. Function now returns `true` if the window was shown, `false` on all early-exit paths.
- **`Listeners/LootListener_Classic.lua`** — captures the `Show()` return value and gates the `DRAGONTOAST_SUPPRESS` MessageBridge send on it instead of `not autoLoot`, so toast suppression mirrors actual window visibility (prevents duplicate toasts for items the window now displays under auto-loot).

No config surface change. Retail listener unaffected — version guard at the top of `LootListener_Classic.lua` keeps this scoped to non-mainline.

## Verification

- `luacheck .` — 0 warnings / 0 errors across 46 files.
- `busted --verbose` — 29 successes / 0 failures.
- In-game verification pending (TBC Anniversary):
  - [ ] Auto-loot ON + trash mob → no window (unchanged).
  - [ ] Auto-loot ON + dungeon boss / chest with rolls → window appears for the leftover items.
  - [ ] Auto-loot ON + solo BoP-confirm corpse → window appears for the BoP item.
  - [ ] Auto-loot OFF → window works as before.

## Follow-up (out of scope)

- Retail listener (`LootListener_Retail.lua`) also calls `Show()` and currently ignores the return value. Backward-compatible (`Show()` return is optional), but for parity the same `shown` gate should be applied if retail ever exhibits the same mixed-mode behavior. Flagged by code review as a NIT.
- Reviewer also flagged a medium-risk refactor opportunity to consolidate the engine-auto-loot and smart-auto-loot branches in `Show()`. Deferred — not appropriate to bundle into a bug-fix PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Loot interface now remains visible for items that cannot be auto-looted during auto-loot operations
  * Fixed notification behavior to only display when the loot UI is actively shown

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Xerrion/DragonLoot/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->