### PR TITLE
feat: add item comparison tooltips to loot and roll frames (#162)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,6 +56,7 @@ files["DragonLoot/"] = {
         "InterfaceOptionsFrame_OpenToCategory", "Settings",
         "ShowUIPanel",
         "IsModifiedClick", "GameTooltip_ShowCompareItem",
+        "GetCVarBool",
 
         -- WoW API - Loot
         "GetNumLootItems", "GetLootSlotInfo", "GetLootSlotLink", "GetLootSlotType",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -55,6 +55,7 @@ files["DragonLoot/"] = {
         "InCombatLockdown", "hooksecurefunc",
         "InterfaceOptionsFrame_OpenToCategory", "Settings",
         "ShowUIPanel",
+        "IsModifiedClick", "GameTooltip_ShowCompareItem",
 
         -- WoW API - Loot
         "GetNumLootItems", "GetLootSlotInfo", "GetLootSlotLink", "GetLootSlotType",
@@ -73,6 +74,7 @@ files["DragonLoot/"] = {
         "LootFrame",
         "GroupLootFrame1", "GroupLootFrame2", "GroupLootFrame3", "GroupLootFrame4",
         "GroupLootContainer",
+        "ShoppingTooltip1", "ShoppingTooltip2",
 
         -- WoW Globals - Version detection
         "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE",

--- a/DragonLoot/Display/LootFrame.lua
+++ b/DragonLoot/Display/LootFrame.lua
@@ -13,6 +13,11 @@ local _, ns = ...
 
 local CreateFrame = CreateFrame
 local GameTooltip = GameTooltip
+local GameTooltip_ShowCompareItem = GameTooltip_ShowCompareItem
+local GetCVarBool = GetCVarBool
+local IsModifiedClick = IsModifiedClick
+local ShoppingTooltip1 = ShoppingTooltip1
+local ShoppingTooltip2 = ShoppingTooltip2
 local UIParent = UIParent
 local GetNumLootItems = GetNumLootItems
 local GetLootSlotInfo = GetLootSlotInfo
@@ -262,6 +267,45 @@ local function PositionAtCursor()
 end
 
 -------------------------------------------------------------------------------
+-- Item comparison tooltip helpers
+-------------------------------------------------------------------------------
+
+local function ShowCompareItem(self)
+    if not self._comparing then
+        self._comparing = true
+        GameTooltip_ShowCompareItem()
+    end
+end
+
+local function HideCompareItem(self)
+    if self._comparing then
+        self._comparing = false
+        if ShoppingTooltip1 then
+            ShoppingTooltip1:Hide()
+        end
+        if ShoppingTooltip2 then
+            ShoppingTooltip2:Hide()
+        end
+    end
+end
+
+local function ShouldShowCompareItem()
+    return IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")
+end
+
+local function OnSlotCompareUpdate(self)
+    if ShouldShowCompareItem() then
+        -- Re-show if shopping tooltips were hidden externally (e.g. modifier state change)
+        if self._comparing and ShoppingTooltip1 and not ShoppingTooltip1:IsShown() then
+            self._comparing = false
+        end
+        ShowCompareItem(self)
+    else
+        HideCompareItem(self)
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Named slot interaction scripts (reusable / restorable after test mode)
 -------------------------------------------------------------------------------
 
@@ -277,6 +321,11 @@ local function OnSlotEnter(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         GameTooltip:SetLootItem(self.slotIndex)
         GameTooltip:Show()
+
+        if ShouldShowCompareItem() then
+            ShowCompareItem(self)
+        end
+        self:SetScript("OnUpdate", OnSlotCompareUpdate)
     end
 
     -- Visual hover effects
@@ -299,6 +348,8 @@ local function OnSlotEnter(self)
 end
 
 local function OnSlotLeave(self)
+    self:SetScript("OnUpdate", nil)
+    HideCompareItem(self)
     GameTooltip:Hide()
 
     -- Restore visual state
@@ -443,6 +494,8 @@ local function ReleaseSlot(slot)
     slot.highlight:SetColorTexture(1, 1, 1, 0.15)
     slot._qr, slot._qg, slot._qb = nil, nil, nil
     slot._quality = nil
+    slot._comparing = nil
+    slot:SetScript("OnUpdate", nil)
 
     -- Restore real interaction scripts (test mode may have overridden them)
     slot:SetScript("OnClick", OnSlotClick)

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -14,6 +14,11 @@ local _, ns = ...
 local CreateFrame = CreateFrame
 local C_Timer = C_Timer
 local GameTooltip = GameTooltip
+local GameTooltip_ShowCompareItem = GameTooltip_ShowCompareItem
+local GetCVarBool = GetCVarBool
+local IsModifiedClick = IsModifiedClick
+local ShoppingTooltip1 = ShoppingTooltip1
+local ShoppingTooltip2 = ShoppingTooltip2
 local UIParent = UIParent
 local GetLootRollItemInfo = GetLootRollItemInfo
 local GetLootRollItemLink = GetLootRollItemLink
@@ -498,6 +503,45 @@ local function OnRollButtonLeave()
 end
 
 -------------------------------------------------------------------------------
+-- Item comparison tooltip helpers
+-------------------------------------------------------------------------------
+
+local function ShowCompareItem(self)
+    if not self._comparing then
+        self._comparing = true
+        GameTooltip_ShowCompareItem()
+    end
+end
+
+local function HideCompareItem(self)
+    if self._comparing then
+        self._comparing = false
+        if ShoppingTooltip1 then
+            ShoppingTooltip1:Hide()
+        end
+        if ShoppingTooltip2 then
+            ShoppingTooltip2:Hide()
+        end
+    end
+end
+
+local function ShouldShowCompareItem()
+    return IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")
+end
+
+local function OnIconCompareUpdate(self)
+    if ShouldShowCompareItem() then
+        -- Re-show if shopping tooltips were hidden externally (e.g. modifier state change)
+        if self._comparing and ShoppingTooltip1 and not ShoppingTooltip1:IsShown() then
+            self._comparing = false
+        end
+        ShowCompareItem(self)
+    else
+        HideCompareItem(self)
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Icon tooltip handlers
 -------------------------------------------------------------------------------
 
@@ -513,10 +557,17 @@ local function OnIconEnter(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         GameTooltip:SetLootRollItem(frame.rollID)
         GameTooltip:Show()
+
+        if ShouldShowCompareItem() then
+            ShowCompareItem(self)
+        end
+        self:SetScript("OnUpdate", OnIconCompareUpdate)
     end
 end
 
-local function OnIconLeave()
+local function OnIconLeave(self)
+    self:SetScript("OnUpdate", nil)
+    HideCompareItem(self)
     GameTooltip:Hide()
 end
 

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -1074,6 +1074,8 @@ local function ReleaseRollFrame(index)
     frame.testItemName = nil
     frame.testQuality = nil
     frame.rollID = nil
+    frame.iconFrame._comparing = nil
+    frame.iconFrame:SetScript("OnUpdate", nil)
     frame:Hide()
 end
 


### PR DESCRIPTION
## Description

Closes https://github.com/Xerrion/DragonLoot/issues/162

Adds item comparison tooltip support to the custom loot frame and roll frame, matching the behavior of Blizzard's default frames.

When hovering over an item in the loot window or roll frame, pressing the Compare Items modifier key (default: Shift) now shows shopping comparison tooltips for the currently equipped item(s). The implementation also respects the `alwaysCompareItems` CVar — when enabled, comparison tooltips appear automatically on hover without requiring a modifier key.

### Changes

- `LootFrame.lua`: Added comparison tooltip logic to `OnSlotEnter`/`OnSlotLeave` with an `OnUpdate` handler that tracks modifier key state changes while hovering
- `RollFrame.lua`: Added the same comparison tooltip logic to `OnIconEnter`/`OnIconLeave` for roll frame item icons
- `.luacheckrc`: Added new WoW API globals (`IsModifiedClick`, `GameTooltip_ShowCompareItem`, `GetCVarBool`, `ShoppingTooltip1`, `ShoppingTooltip2`)

### Implementation details

- Uses `IsModifiedClick("COMPAREITEMS")` to respect the player's keybinding configuration (never hardcodes Shift)
- Uses `GetCVarBool("alwaysCompareItems")` to support the always-compare CVar
- Uses `GameTooltip_ShowCompareItem()` — the standard Blizzard helper available on all supported WoW versions
- Handles both interaction patterns: pressing the modifier while hovering, and hovering while the modifier is already held
- Detects externally hidden shopping tooltips (e.g. from Blizzard's `MODIFIER_STATE_CHANGED` handler) and re-shows them when the CVar is active
- Comparison is skipped in test mode (no real item data to compare against)
- `OnUpdate` is only active while the cursor is over an item slot — no idle CPU cost
- Works on `Retail`, `MoP Classic`, and `TBC Anniversary`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] Luacheck passes (`luacheck .`) - no new warnings
- [x] Tested in-game manually - looted items with and without CVar set
- [x] WoW version(s) tested on: TBC Anniversary

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [x] I have tested my changes in-game
- [x] Luacheck reports no **(new)** warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Item comparison tooltips now display dynamically when hovering over items in loot and roll windows. These tooltips respond intelligently to your modifier key inputs and game settings, giving you customizable control over when item comparisons appear. The comparison tooltip automatically closes whenever you move your cursor away from an item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Xerrion/DragonLoot/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->