### PR TITLE
fix(roll): always hide roll frame on vote to prevent queuing lock (#161)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,11 +6,11 @@ language: en-US
 inheritance: true
 
 tone_instructions: >-
-  Review WoW addon Lua code. Focus on nil safety, global leaks,
+  Review WoW addon Lua code. Focus on nil safety, global leaks, best practices,
   event hygiene, and taint risks. Skip style - luacheck handles it.
 
 reviews:
-  profile: chill
+  profile: assertive
   high_level_summary: true
   poem: false
   sequence_diagrams: false

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -52,7 +52,6 @@ local defaults = {
             frameSpacing = 4,
             frameMinHeight = 68,
             compactTextLayout = false,
-            hideOnVote = false,
             iconPosition = "inside",
             iconSide = "left",
             iconOffsetX = 0,

--- a/DragonLoot/Display/RollFrame.lua
+++ b/DragonLoot/Display/RollFrame.lua
@@ -461,18 +461,12 @@ local function OnRollButtonClick(self)
     if frame.rollID then
         -- Mark pending hide BEFORE RollOnLoot; synchronous CONFIRM_LOOT_ROLL
         -- will clear the flag if a confirmation popup is needed.
-        local rollCfg = GetRollFrameDB()
-        local shouldHide = rollCfg and rollCfg.hideOnVote
-        if shouldHide then
-            ns.RollManager.MarkPendingHide(frame.rollID)
-        end
+        ns.RollManager.MarkPendingHide(frame.rollID)
 
         RollOnLoot(frame.rollID, self.rollType)
 
         -- Hide now unless CONFIRM_LOOT_ROLL intercepted (flag cleared)
-        if shouldHide then
-            ns.RollManager.TryHideAfterVote(frame.rollID)
-        end
+        ns.RollManager.TryHideAfterVote(frame.rollID)
     end
 end
 

--- a/DragonLoot/Display/RollManager.lua
+++ b/DragonLoot/Display/RollManager.lua
@@ -102,11 +102,8 @@ StaticPopupDialogs["DRAGONLOOT_CONFIRM_LOOT_ROLL"] = {
             return
         end
         ConfirmLootRoll(self.data.rollID, self.data.rollType)
-        -- Hide frame after confirming BoP roll if configured
-        local db = ns.Addon.db
-        if db and db.profile and db.profile.rollFrame and db.profile.rollFrame.hideOnVote then
-            HideAfterVote(self.data.rollID)
-        end
+        -- Hide frame after confirming BoP roll
+        HideAfterVote(self.data.rollID)
     end,
     timeout = 0,
     whileDead = 1,

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -220,10 +220,6 @@ L["Show in Dungeons"] = true
 L["Show in Open World"] = true
 L["Show in Raids"] = true
 L["Show individual roll result notifications"] = true
-L["Hide After Voting"] = true
--- stylua: ignore
-L["Hide the roll frame after you cast your vote. The roll continues in the background"
-    .. " and notifications still fire."] = true
 L["Show item name and bind type on the same line"] = true
 L["Show notifications for other group members' roll results"] = true
 L["Show notifications for your own roll results"] = true

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -133,21 +133,6 @@ local function CreateRollFrameSection(parent, db, yOffset, layoutWidgets, reappl
     layoutWidgets[#layoutWidgets + 1] = lockToggle
     innerY = LC.AnchorWidget(lockToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local hideOnVoteToggle = W.CreateToggle(content, {
-        label = L["Hide After Voting"],
-        -- stylua: ignore
-        tooltip = L["Hide the roll frame after you cast your vote. The roll continues in the background"
-            .. " and notifications still fire."],
-        get = function()
-            return db.profile.rollFrame.hideOnVote
-        end,
-        set = function(value)
-            db.profile.rollFrame.hideOnVote = value
-        end,
-    })
-    layoutWidgets[#layoutWidgets + 1] = hideOnVoteToggle
-    innerY = LC.AnchorWidget(hideOnVoteToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
     local centerHBtn = W.CreateButton(content, {
         text = L["Center Horizontally"],
         width = 130,


### PR DESCRIPTION
## Summary
- Always hide the roll frame immediately after voting to prevent roll frames queuing up and locking when the option was disabled.

## Changes
- \DragonLoot/Core/Config.lua\ - Removed \hideOnVote\ profile default configuration option.
- \DragonLoot/Display/RollFrame.lua\ - Always execute \MarkPendingHide\ and \TryHideAfterVote\ upon casting a vote.
- \DragonLoot/Display/RollManager.lua\ - Always execute \HideAfterVote\ upon confirmation of roll button click.
- \DragonLoot/Locales/enUS.lua\ - Removed localization strings for "Hide After Voting".
- \DragonLoot_Options/Tabs/LootRollTab.lua\ - Removed the toggle configuration widget from the options tab.
- \.coderabbit.yaml\ - Adjusted reviewer settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the "Hide After Voting" setting; roll frames now automatically hide after voting.
  * Updated automated review configuration to use a more assertive tone and reference best practices.
* **Documentation**
  * Removed localization entries related to the deprecated "Hide After Voting" option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Xerrion/DragonLoot/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->