### PR TITLE
fix(history): resolve overlapping rows with adjustable padding (#165)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,14 +66,15 @@ The repository is structured as a multi-addon project separating core logic, con
 
 ### History (`db.profile.history`)
 
-| Key             | Type    | Default |
-| --------------- | ------- | ------- |
-| enabled         | boolean | true    |
-| maxEntries      | number  | 50      |
-| autoShow        | boolean | false   |
-| lock            | boolean | false   |
-| trackDirectLoot | boolean | true    |
-| minQuality      | number  | 2       |
+| Key              | Type    | Default |
+| ---------------- | ------- | ------- |
+| enabled          | boolean | true    |
+| maxEntries       | number  | 50      |
+| autoShow         | boolean | false   |
+| lock             | boolean | false   |
+| trackDirectLoot  | boolean | true    |
+| minQuality       | number  | 2       |
+| rowHeightPadding | number  | 6       |
 
 ## Version-Specific API Differences
 

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -130,7 +130,7 @@ local defaults = {
 
     char = {
         history = {
-            entries = {},   -- persisted loot history entries; populated at runtime
+            entries = {}, -- persisted loot history entries; populated at runtime
             schemaVersion = 4,
         },
     },

--- a/DragonLoot/Core/Config.lua
+++ b/DragonLoot/Core/Config.lua
@@ -70,6 +70,7 @@ local defaults = {
             minQuality = 2, -- Uncommon
             entrySpacing = 2,
             contentPadding = 6,
+            rowHeightPadding = 6,
             showRollDetails = true,
         },
 

--- a/DragonLoot/Core/Init.lua
+++ b/DragonLoot/Core/Init.lua
@@ -208,10 +208,14 @@ local function SuppressBlizzardRollFrames()
         if _G.GroupLootContainer_AddRoll then
             hooksecurefunc("GroupLootContainer_AddRoll", function()
                 if suppressRollContainer then
-                    if GroupLootContainer then GroupLootContainer:Hide() end
+                    if GroupLootContainer then
+                        GroupLootContainer:Hide()
+                    end
                     for i = 1, 4 do
                         local f = _G["GroupLootFrame" .. i]
-                        if f then f:Hide() end
+                        if f then
+                            f:Hide()
+                        end
                     end
                 end
             end)

--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -164,7 +164,17 @@ local function GetHistoryIconSize()
 end
 
 local function GetEntryHeight()
-    return GetHistoryIconSize() + 6
+    local historyDB = GetHistoryDB()
+    local padding = historyDB and historyDB.rowHeightPadding or 6
+    return GetHistoryIconSize() + padding
+end
+
+local function AlignEntryHeader(entry)
+    local entryHeight = GetEntryHeight()
+    local iconSize = GetHistoryIconSize()
+    local iconOffset = (entryHeight - iconSize) / 2
+    entry.icon:ClearAllPoints()
+    entry.icon:SetPoint("TOPLEFT", entry, "TOPLEFT", 2, -iconOffset)
 end
 
 local function ApplyLayoutOffsets(frame)
@@ -288,7 +298,7 @@ local function CreateEntryFrame()
     entry.icon = entry:CreateTexture(nil, "ARTWORK")
     local iconSize = GetHistoryIconSize()
     entry.icon:SetSize(iconSize, iconSize)
-    entry.icon:SetPoint("LEFT", entry, "LEFT", 2, 0)
+    AlignEntryHeader(entry)
     entry.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
     -- Icon border
@@ -608,6 +618,14 @@ end
 -------------------------------------------------------------------------------
 
 local function PopulateEntry(entry, data)
+    if not entry or not data then
+        return
+    end
+
+    local iconSize = GetHistoryIconSize()
+    entry.icon:SetSize(iconSize, iconSize)
+    AlignEntryHeader(entry)
+
     entry.itemLink = data.itemLink
     entry.timestamp = data.timestamp
     entry.wallTime = data.wallTime
@@ -1118,6 +1136,7 @@ function ns.HistoryFrame.ApplySettings()
         if entry:IsShown() then
             entry:SetHeight(entryHeight)
             entry.icon:SetSize(iconSize, iconSize)
+            AlignEntryHeader(entry)
             entry.itemName:SetFont(fontPath, fontSize - 1, fontOutline)
             DU.ApplyFontShadow(entry.itemName, ns.Addon.db)
             entry.winnerName:SetFont(fontPath, fontSize - 2, fontOutline)

--- a/DragonLoot/Display/HistoryFrame.lua
+++ b/DragonLoot/Display/HistoryFrame.lua
@@ -486,7 +486,9 @@ end
 -------------------------------------------------------------------------------
 
 local function OnEntryEnter(self)
-    if not self.itemLink then return end
+    if not self.itemLink then
+        return
+    end
 
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
     GameTooltip:SetHyperlink(self.itemLink)
@@ -502,7 +504,7 @@ local function OnEntryEnter(self)
             local aPass = (a.rollType == 0) or not a.roll
             local bPass = (b.rollType == 0) or not b.roll
             if aPass ~= bPass then
-                return not aPass  -- non-pass first
+                return not aPass -- non-pass first
             end
             return (a.roll or 0) > (b.roll or 0)
         end)

--- a/DragonLoot/Listeners/HistoryListener_Classic.lua
+++ b/DragonLoot/Listeners/HistoryListener_Classic.lua
@@ -152,11 +152,13 @@ local function RefreshFromAPI()
             return at > bt
         end)
 
-        local maxEntries = (ns.Addon
+        local maxEntries = (
+            ns.Addon
             and ns.Addon.db
             and ns.Addon.db.profile
             and ns.Addon.db.profile.history
-            and ns.Addon.db.profile.history.maxEntries) or 100
+            and ns.Addon.db.profile.history.maxEntries
+        ) or 100
         while #entries > maxEntries do
             entries[#entries] = nil
         end

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -260,6 +260,7 @@ L["Recording"] = true
 L["Auto Show on Loot"] = true
 L["Enable History"] = true
 L["Entry Spacing"] = true
+L["Row Height Padding"] = true
 L["History"] = true
 L["Max Entries"] = true
 L["Prevent the history frame from being moved"] = true

--- a/DragonLoot/Locales/enUS.lua
+++ b/DragonLoot/Locales/enUS.lua
@@ -60,12 +60,12 @@ L["Toggle on/off"] = true
 L["DragonLoot_Options addon not found. Please ensure it is installed."] = true
 
 -- Core/ElvUICompat.lua
-L["ElvUI's loot window is enabled and conflicts with DragonLoot."
-    .. " Disable ElvUI's loot modules and reload now?"] = true
-L["ElvUI's group-loot roll frames are enabled and conflict with DragonLoot."
-    .. " Disable ElvUI's roll frames and reload now?"] = true
-L["ElvUI's loot window and group-loot roll frames are enabled and conflict with DragonLoot."
-    .. " Disable both ElvUI modules and reload now?"] = true
+L["ElvUI's loot window is enabled and conflicts with DragonLoot." .. " Disable ElvUI's loot modules and reload now?"] =
+    true
+L["ElvUI's group-loot roll frames are enabled and conflict with DragonLoot." .. " Disable ElvUI's roll frames and reload now?"] =
+    true
+L["ElvUI's loot window and group-loot roll frames are enabled and conflict with DragonLoot." .. " Disable both ElvUI modules and reload now?"] =
+    true
 
 -- Display/LootFrame.lua
 L["BoE"] = true

--- a/DragonLoot_Options/Tabs/AnimationTab.lua
+++ b/DragonLoot_Options/Tabs/AnimationTab.lua
@@ -158,15 +158,13 @@ local function CreateContent(parent)
     local lootY = -LC.SECTION_PADDING_TOP
 
     local lootOpenDropdown
-    lootY, lootOpenDropdown = CreateAnimDropdown(
-        lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues
-    )
+    lootY, lootOpenDropdown =
+        CreateAnimDropdown(lootContent, db, lootY, L["Open Animation"], "lootOpenAnim", GetEntranceValues)
     animWidgets[#animWidgets + 1] = lootOpenDropdown
 
     local lootCloseDropdown
-    lootY, lootCloseDropdown = CreateAnimDropdown(
-        lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues
-    )
+    lootY, lootCloseDropdown =
+        CreateAnimDropdown(lootContent, db, lootY, L["Close Animation"], "lootCloseAnim", GetExitValues)
     animWidgets[#animWidgets + 1] = lootCloseDropdown
 
     lootSection:SetContentHeight(math_abs(lootY) + LC.SECTION_PADDING_BOTTOM)
@@ -180,15 +178,13 @@ local function CreateContent(parent)
     local rollY = -LC.SECTION_PADDING_TOP
 
     local rollShowDropdown
-    rollY, rollShowDropdown = CreateAnimDropdown(
-        rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues
-    )
+    rollY, rollShowDropdown =
+        CreateAnimDropdown(rollContent, db, rollY, L["Show Animation"], "rollShowAnim", GetEntranceValues)
     animWidgets[#animWidgets + 1] = rollShowDropdown
 
     local rollHideDropdown
-    rollY, rollHideDropdown = CreateAnimDropdown(
-        rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues
-    )
+    rollY, rollHideDropdown =
+        CreateAnimDropdown(rollContent, db, rollY, L["Hide Animation"], "rollHideAnim", GetExitValues)
     animWidgets[#animWidgets + 1] = rollHideDropdown
 
     rollSection:SetContentHeight(math_abs(rollY) + LC.SECTION_PADDING_BOTTOM)

--- a/DragonLoot_Options/Tabs/HistoryTab.lua
+++ b/DragonLoot_Options/Tabs/HistoryTab.lua
@@ -241,6 +241,23 @@ local function CreateDisplaySection(parent, db, yOffset)
     })
     innerY = LC.AnchorWidget(contentPaddingSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
+    -- Slider: Row Height Padding
+    local rowHeightPaddingSlider = W.CreateSlider(content, {
+        label = L["Row Height Padding"],
+        min = 2,
+        max = 20,
+        step = 1,
+        format = "%d",
+        get = function()
+            return db.profile.history.rowHeightPadding or 6
+        end,
+        set = function(value)
+            db.profile.history.rowHeightPadding = value
+            ApplyHistorySettings()
+        end,
+    })
+    innerY = LC.AnchorWidget(rowHeightPaddingSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
     -- Clear History button (destructive action)
     local clearBtn = W.CreateButton(content, {
         text = L["Clear History"],

--- a/DragonLoot_Options/Tabs/LootRollTab.lua
+++ b/DragonLoot_Options/Tabs/LootRollTab.lua
@@ -224,10 +224,29 @@ local function CreateFrameSection(parent, db, yOffset, layoutWidgets, reapplySub
     innerY = LC.AnchorWidget(frameMinHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Scale"], L["Roll frame scale"], "scale", 0.5, 2, 0.05, "%.2f", layoutWidgets
+        content,
+        db,
+        innerY,
+        L["Scale"],
+        L["Roll frame scale"],
+        "scale",
+        0.5,
+        2,
+        0.05,
+        "%.2f",
+        layoutWidgets
     )
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Frame Width"], L["Width of the roll frame"], "frameWidth", 200, 500, 10, "%d",
+        content,
+        db,
+        innerY,
+        L["Frame Width"],
+        L["Width of the roll frame"],
+        "frameWidth",
+        200,
+        500,
+        10,
+        "%d",
         layoutWidgets
     )
 
@@ -353,8 +372,17 @@ local function CreateTimerBarSection(parent, db, yOffset, layoutWidgets, reapply
     innerY = LC.AnchorWidget(minimalHeightSlider, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Timer Bar Spacing"], L["Space between item row and timer bar"], "timerBarSpacing",
-        0, 16, 1, "%d", layoutWidgets
+        content,
+        db,
+        innerY,
+        L["Timer Bar Spacing"],
+        L["Space between item row and timer bar"],
+        "timerBarSpacing",
+        0,
+        16,
+        1,
+        "%d",
+        layoutWidgets
     )
 
     local textureDropdown = W.CreateDropdown(content, {
@@ -508,20 +536,56 @@ local function CreateButtonsSection(parent, db, yOffset, layoutWidgets)
     local innerY = -LC.SECTION_PADDING_TOP
 
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Button Size"], L["Size of Need/Greed/Pass buttons"], "buttonSize", 16, 36, 1, "%d",
+        content,
+        db,
+        innerY,
+        L["Button Size"],
+        L["Size of Need/Greed/Pass buttons"],
+        "buttonSize",
+        16,
+        36,
+        1,
+        "%d",
         layoutWidgets
     )
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Button Spacing"], L["Spacing between roll buttons"], "buttonSpacing", 0, 12, 1, "%d",
+        content,
+        db,
+        innerY,
+        L["Button Spacing"],
+        L["Spacing between roll buttons"],
+        "buttonSpacing",
+        0,
+        12,
+        1,
+        "%d",
         layoutWidgets
     )
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Frame Spacing"], L["Spacing between multiple roll frames"], "frameSpacing", 0, 16, 1,
-        "%d", layoutWidgets
+        content,
+        db,
+        innerY,
+        L["Frame Spacing"],
+        L["Spacing between multiple roll frames"],
+        "frameSpacing",
+        0,
+        16,
+        1,
+        "%d",
+        layoutWidgets
     )
     innerY = CreateLayoutSlider(
-        content, db, innerY, L["Content Padding"], L["Inner padding of the roll frame"], "contentPadding", 0, 12, 1,
-        "%d", layoutWidgets
+        content,
+        db,
+        innerY,
+        L["Content Padding"],
+        L["Inner padding of the roll frame"],
+        "contentPadding",
+        0,
+        12,
+        1,
+        "%d",
+        layoutWidgets
     )
 
     section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)


### PR DESCRIPTION
## Summary
- Resolves issue where history entries overlap or have insufficient/rigid padding.
- Adds an adjustable 'rowHeightPadding' slider to the history options tab.
- Dynamically updates entry frame heights and recalculates layout/offsets when the setting is modified.

## Changes
- AGENTS.md: Added documentation schema reference for 'rowHeightPadding'
- Config.lua: Defined 'rowHeightPadding = 6' default profile configuration
- HistoryFrame.lua: Implemented variable entry height with customizable padding and aligned entry headers appropriately
- enUS.lua: Added locale key for 'Row Height Padding'
- HistoryTab.lua: Added 'Row Height Padding' slider control

Closes #165