### PR TITLE
chore: drop TWW Retail support and add Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,8 +9,8 @@
 
 - Do not use `require`. Load libraries with `LibStub("LibName-X.Y")`.
 - Flag Lua 5.2+ syntax or APIs, including `_ENV`, `goto`, `table.pack`, `table.unpack`, `bit32`, and `//`.
-- Each file starts with the standard header: 80 hyphens, filename, one-line description, blank line, `-- Supported versions: ...`, then `local ADDON_NAME, ns = ...`.
-- Keep addon state in `ns`; only `DragonLootDB` and `SLASH_DRAGONLOOT1/2` should be real globals.
+- Each file starts with the standard header: 80 hyphens, filename, one-line description, blank line, `-- Supported versions: ...`, then either `local ADDON_NAME, ns = ...` or `local _, ns = ...` when the addon name is unused.
+- Keep addon state in `ns` where possible; accepted globals include `DragonLootDB`, `SLASH_DRAGONLOOT1/2`, `DragonLootNS` for the LoadOnDemand options bridge, and the `DragonLoot_Options` global API.
 - Naming: PascalCase files and functions, camelCase locals, UPPER_SNAKE_CASE module constants.
 - Use 4 spaces, no tabs, double quotes, Unix line endings, and 120-character lines. `Locales/*.lua` is exempt from the line-length rule.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# DragonLoot Copilot review instructions
+
+## About this project
+
+- DragonLoot is a World of Warcraft addon written for Lua 5.1.
+- It targets three flavors: Retail (Midnight, interface 120005), MoP Classic (Mists, 50503), and TBC Anniversary (BCC, 20505). Use `WOW_PROJECT_ID` and explicit interface checks for version-specific code.
+
+## Lua conventions
+
+- Do not use `require`. Load libraries with `LibStub("LibName-X.Y")`.
+- Flag Lua 5.2+ syntax or APIs, including `_ENV`, `goto`, `table.pack`, `table.unpack`, `bit32`, and `//`.
+- Each Lua file starts with the standard header: 80 hyphens, filename, one-line description, blank line, `-- Supported versions: ...`, then `local ADDON_NAME, ns = ...`.
+- Keep addon state in `ns`; only `DragonLootDB` and `SLASH_DRAGONLOOT1/2` should be real globals.
+- Naming: PascalCase files and functions, camelCase locals, UPPER_SNAKE_CASE module constants.
+- Use 4 spaces, no tabs, double quotes, Unix line endings, and 120-character lines. `Locales/*.lua` is exempt from the line-length rule.
+
+## WoW API patterns
+
+- Cache WoW API globals and Lua globals as locals at file top, for example `local GetTime = GetTime`.
+- Do not rely on TOC packager directives for runtime safety. Locally, all version-specific files load because directives are comments.
+- Use BigWigsMods packager directives in TOC files for flavor-specific loading, for example `#@retail@` ... `#@end-retail@`. Never add `## Interface:` mid-TOC to gate files.
+- Guard version-specific logic with `WOW_PROJECT_ID` checks and explicit API availability checks where needed.
+
+## AceLocale pattern
+
+- Locale keys are full English sentences, not short symbolic keys.
+- Base `enUS` files use `LibStub("AceLocale-3.0"):NewLocale(ADDON_NAME, "enUS", true, true)` and `L["Full English sentence"] = true`.
+- Other locale files use `NewLocale(ADDON_NAME, "locale")` and set translated string values.
+- In options code, prefer `local L = ns.L` after `Core.lua` exposes the main addon's locale.
+
+## Critical gotchas
+
+- Retail Midnight 12.0+ removes addon access to `COMBAT_LOG_EVENT_UNFILTERED`; `CombatLogGetCurrentEventInfo()` can return obfuscated values. Flag new CLEU parsing in retail-targeted code. Prefer `UNIT_SPELLCAST_INTERRUPT`, `UNIT_SPELLCAST_SUCCEEDED`, `UNIT_AURA`, `C_UnitAuras`, and `C_Spell` APIs.
+- Ace3 `AceEvent30Frame` is a shared named global frame. Taint from one addon can affect all AceEvent consumers. Flag `addon:RegisterEvent` for high-traffic or sensitive events; prefer a private unnamed `CreateFrame("Frame")` for those registrations.
+
+## DragonLoot specifics
+
+- Config writes must match the AceDB schema under `db.profile.appearance`, `db.profile.history`, `db.profile.lootWindow`, `db.profile.rollFrame`, `db.profile.notifications`, `db.profile.autoLoot`, or `db.profile.animation`.
+- Inter-addon messaging goes through `ns.MessageBridge` over AceComm. Treat messages as fire-and-forget and do not add hard dependencies on DragonToast or other addons.
+- Retail and Classic loot APIs differ. Check tuple sizes and field names before approving shared listener code.
+- If code suppresses Blizzard loot frames or events, verify it restores them on disable, shutdown, and error paths that leave the custom UI closed.
+- Fetch roll item data before `CancelRoll`; the data is unavailable after canceling.
+
+## Verification
+
+- `just check` is the local gate; it runs `stylua --check`, `luacheck`, and `busted`.
+- Code should pass all three checks without new warnings or failing tests.
+- Do not flag long `L[...]` locale-key bracket lines solely because StyLua cannot wrap inside them.
+
+## Commit and PR conventions
+
+- Commit subjects use conventional prefixes: `feat:`, `fix:`, `chore:`, `style:`, `refactor:`, `test:`, `docs:`, or `ci:`.
+- Reference issues as `(#123)` when present.
+- The default branch is `master`; PRs are squash-merged.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,23 +3,23 @@
 ## About this project
 
 - DragonLoot is a World of Warcraft addon written for Lua 5.1.
-- It targets three flavors: Retail (Midnight, interface 120005), MoP Classic (Mists, 50503), and TBC Anniversary (BCC, 20505). Use `WOW_PROJECT_ID` and explicit interface checks for version-specific code.
+- It targets three flavors: Retail (Midnight, 120005), MoP Classic (Mists, 50503), and TBC Anniversary (BCC, 20505). Use `WOW_PROJECT_ID` and interface checks for version-specific code.
 
 ## Lua conventions
 
 - Do not use `require`. Load libraries with `LibStub("LibName-X.Y")`.
 - Flag Lua 5.2+ syntax or APIs, including `_ENV`, `goto`, `table.pack`, `table.unpack`, `bit32`, and `//`.
-- Each Lua file starts with the standard header: 80 hyphens, filename, one-line description, blank line, `-- Supported versions: ...`, then `local ADDON_NAME, ns = ...`.
+- Each file starts with the standard header: 80 hyphens, filename, one-line description, blank line, `-- Supported versions: ...`, then `local ADDON_NAME, ns = ...`.
 - Keep addon state in `ns`; only `DragonLootDB` and `SLASH_DRAGONLOOT1/2` should be real globals.
 - Naming: PascalCase files and functions, camelCase locals, UPPER_SNAKE_CASE module constants.
 - Use 4 spaces, no tabs, double quotes, Unix line endings, and 120-character lines. `Locales/*.lua` is exempt from the line-length rule.
 
 ## WoW API patterns
 
-- Cache WoW API globals and Lua globals as locals at file top, for example `local GetTime = GetTime`.
+- Cache WoW API and Lua globals as locals at file top, e.g. `local GetTime = GetTime`.
 - Do not rely on TOC packager directives for runtime safety. Locally, all version-specific files load because directives are comments.
-- Use BigWigsMods packager directives in TOC files for flavor-specific loading, for example `#@retail@` ... `#@end-retail@`. Never add `## Interface:` mid-TOC to gate files.
-- Guard version-specific logic with `WOW_PROJECT_ID` checks and explicit API availability checks where needed.
+- Use BigWigsMods packager directives in TOC files for flavor-specific loading, e.g. `#@retail@` ... `#@end-retail@`. Never add `## Interface:` mid-TOC to gate files.
+- Guard version-specific logic with `WOW_PROJECT_ID` checks and API availability checks.
 
 ## AceLocale pattern
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Target Versions
 
-| Version         | Interface              | TOC Directive                          |
-| --------------- | ---------------------- | -------------------------------------- |
-| Retail          | 120005, 110207, 120000 | `## Interface: 120005, 110207, 120000` |
-| TBC Anniversary | 20505                  | `## Interface-BCC: 20505`              |
-| MoP Classic     | 50503                  | `## Interface-Mists: 50503`            |
+| Version           | Interface | TOC Directive               |
+| ----------------- | --------- | --------------------------- |
+| Retail (Midnight) | 120005    | `## Interface: 120005`      |
+| TBC Anniversary   | 20505     | `## Interface-BCC: 20505`   |
+| MoP Classic       | 50503     | `## Interface-Mists: 50503` |
 
 Version-specific files load via BigWigsMods packager comment directives (`#@retail@` / `#@non-retail@`) in the TOC.
 

--- a/DragonLoot/DragonLoot.toc
+++ b/DragonLoot/DragonLoot.toc
@@ -1,4 +1,4 @@
-## Interface: 120005, 110207, 120000
+## Interface: 120005
 ## Interface-BCC: 20505
 ## Interface-Mists: 50503
 ## Title: Dragon Loot

--- a/DragonLoot/Listeners/RollListener_Retail.lua
+++ b/DragonLoot/Listeners/RollListener_Retail.lua
@@ -1,6 +1,6 @@
 -------------------------------------------------------------------------------
 -- RollListener_Retail.lua
--- Loot roll event handling for Retail (The War Within, Midnight)
+-- Loot roll event handling for Retail (Midnight)
 --
 -- Supported versions: Retail
 -------------------------------------------------------------------------------

--- a/DragonLoot_Options/DragonLoot_Options.toc
+++ b/DragonLoot_Options/DragonLoot_Options.toc
@@ -1,4 +1,4 @@
-## Interface: 120005, 110207, 120000
+## Interface: 120005
 ## Interface-BCC: 20505
 ## Interface-Mists: 50503
 ## Title: DragonLoot Options

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ adds a dedicated loot history panel for tracking drops and winners.
 
 | Client | Interface Versions |
 |---|---|
-| Retail | 120005, 120001, 120000, 110207 |
+| Retail | 120005 |
 | TBC Anniversary | 20505 |
 | MoP Classic | 50503 |
 


### PR DESCRIPTION
Two related changes batched together.

## 1. Drop TWW Retail support

DragonLoot's target Retail version is now **Midnight only** (interface `120005`, current live). The TOC `## Interface:` line is reduced from `120005, 110207, 120000` to just `120005`:

- `110207` (TWW 11.0.x) — dropped per maintainer decision.
- `120000` (Midnight pre-expansion) — obsolete since 12.0.1 (Feb 2026), superseded by 12.0.5 (Apr 2026).

Other targets unchanged: MoP Classic (`50503`), TBC Anniversary (`20505`).

**Files updated** to reflect the new single-interface Retail target:
- `DragonLoot/DragonLoot.toc`, `DragonLoot_Options/DragonLoot_Options.toc` — TOC `## Interface:` line
- `AGENTS.md` — Target Versions table
- `README.md` — Supported Versions table
- `DragonLoot/Listeners/RollListener_Retail.lua` — header comment

No Lua code changes — there were no TWW-specific runtime branches; all retail-side code is intended to keep running on Midnight unchanged.

## 2. Add Copilot review instructions

Adds `.github/copilot-instructions.md` (3,790 bytes, under GitHub's documented 4,000-byte cap for Copilot code review). Distilled from `AGENTS.md` and the workspace `AGENTS.md`, covering:

- Lua 5.1 conventions (no `require`, LibStub, file header, naming, formatting).
- WoW API patterns (cache globals, runtime version guards, TOC packager directives).
- AceLocale key pattern.
- Two critical gotchas: Midnight 12.0+ CLEU removal for addons, and the AceEvent shared-frame taint pattern.
- DragonLoot config schema layout, MessageBridge messaging pattern.
- Verification (`just check`) and commit/PR conventions.

**CodeRabbit is unchanged** — both reviewers will run in parallel during a transition period. CodeRabbit will be removed in a follow-up PR once Copilot's review quality has been validated on a few real PRs.

To request a Copilot review on a PR: open the **Reviewers** menu in the right sidebar and select **Copilot** (not automatic on every commit by default).

## Known: CI lint will fail

Lint will fail on two pre-existing W631 warnings in `DragonLoot/Locales/enUS.lua:65,67`. The fix for those (a `.luacheckrc` per-directory override for `Locales/*.lua`) is on PR #169 and will resolve once that merges. Not in scope here.